### PR TITLE
Change interface to be public

### DIFF
--- a/src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs
+++ b/src/Avalonia.Controls/Utils/CollectionChangedEventManager.cs
@@ -8,7 +8,7 @@ using Avalonia.Utilities;
 
 namespace Avalonia.Controls.Utils
 {
-    internal interface ICollectionChangedListener
+    public interface ICollectionChangedListener
     {
         void PreChanged(INotifyCollectionChanged sender, NotifyCollectionChangedEventArgs e);
         void Changed(INotifyCollectionChanged sender, NotifyCollectionChangedEventArgs e);


### PR DESCRIPTION
## What does the pull request do?
In order to implement this interface outside of the Avalonia project, the interface must be public. This is required e.g. to override the default `ItemsSourceView` in an `ItemsControl`
