### PR TITLE
Create new dispatch methods for Headless EnsureApplication

### DIFF
--- a/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
@@ -117,8 +117,9 @@ public sealed class HeadlessUnitTestSession : IDisposable
         var scope = AvaloniaLocator.EnterScope();
         try
         {
-            Dispatcher.ResetForUnitTests();
+            Dispatcher.UIThread.EmptyAfterUnitTests();
             _appBuilder.SetupUnsafe();
+            Dispatcher.RemakeForUnitTests();
         }
         catch
         {
@@ -129,7 +130,7 @@ public sealed class HeadlessUnitTestSession : IDisposable
         return Disposable.Create(() =>
         {
             scope.Dispose();
-            Dispatcher.ResetForUnitTests();
+            Dispatcher.UIThread.EmptyAfterUnitTests();
         });
     }
 


### PR DESCRIPTION
## What does the pull request do?
Adds two new methods to Dispatcher.Queue that handles before and after setup for headless unit tests.
These are used in an updated HeadlessUnitTestSession.EnsureApplication instead of Dispatcher.ResetForUnitTests. 
Dispatcher.ResetForUnitTests nulled the current UI thread dispatcher instead of renewing it. Dispatcher.RemakeForUnitTests new renews the UI thread instead.


## What is the current behavior?
We are getting PlatformNotSupportedException from Dispatcher.MainLoop when running multiple View tests while using 
HeadlessApplication.


## What is the updated/expected behavior with this PR?
Not hitting PlatformNotSupportedException in Dispatcher.MainLoop when running multiple view tests.


## How was the solution implemented (if it's not obvious)?
See above


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues
None
