### PR TITLE
Fix fuzzy fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,4 @@ node_modules
 src/Browser/Avalonia.Browser.Blazor/webapp/package-lock.json
 src/Browser/Avalonia.Browser.Blazor/wwwroot
 src/Browser/Avalonia.Browser/wwwroot
+.nuke/temp

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -42,16 +42,7 @@
 - (void) updateRenderTarget
 {
     if(_currentRenderTarget) {
-        if (_parent->IsOverlay())
-        {
-            // Powerpoint overlay needs to go without scale factor
-            [_currentRenderTarget resize:_lastPixelSize withScale:1];
-        }
-        else
-        {
-            // Normal views need scale factor in order to avoid fuzzy fonts
-            [_currentRenderTarget resize:_lastPixelSize withScale:static_cast<float>([[self window] backingScaleFactor])];
-        }
+        [_currentRenderTarget resize:_lastPixelSize withScale:static_cast<float>([[self window] backingScaleFactor])];
         [self setNeedsDisplayInRect:[self frame]];
     }
 }
@@ -155,11 +146,6 @@
     _parent->UpdateCursor();
 
     auto fsize = [self convertSizeToBacking: [self frame].size];
-    if (_parent->IsOverlay())
-    {
-        // Powerpoint overlay needs to go without scale factor
-        fsize = [self frame].size;
-    }
 
     if(_lastPixelSize.Width != (int)fsize.width || _lastPixelSize.Height != (int)fsize.height)
     {
@@ -215,11 +201,6 @@
 - (void) viewDidChangeBackingProperties
 {
     auto fsize = [self convertSizeToBacking: [self frame].size];
-    if (_parent->IsOverlay())
-    {
-        // Powerpoint overlay needs to go without scale factor
-        fsize = [self frame].size;
-    }
 
     _lastPixelSize.Width = (int)fsize.width;
     _lastPixelSize.Height = (int)fsize.height;

--- a/override-mac.sh
+++ b/override-mac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-ditto build/Products/Release/libAvalonia.Native.OSX.dylib /Library/Application\ Support/Microsoft/Grunt/Grunt.plugin/Contents/MacOS/libAvaloniaNative.dylib
-
-for f in src/Avalonia.Native/bin/Debug/net6.0/*; do
+for f in src/Avalonia.Desktop/bin/Release/net6.0/*; do
   cp -fv "$f" "/Library/Application Support/Microsoft/Grunt/Grunt.plugin/Contents/MacOS/"
 done
+
+ditto build/Products/Release/libAvalonia.Native.OSX.dylib /Library/Application\ Support/Microsoft/Grunt/Grunt.plugin/Contents/MacOS/libAvaloniaNative.dylib

--- a/override-mac.sh
+++ b/override-mac.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ditto build/Products/Release/libAvalonia.Native.OSX.dylib /Library/Application\ Support/Microsoft/Grunt/Grunt.plugin/Contents/MacOS/libAvaloniaNative.dylib
+
+for f in src/Avalonia.Native/bin/Debug/net6.0/*; do
+  cp -fv "$f" "/Library/Application Support/Microsoft/Grunt/Grunt.plugin/Contents/MacOS/"
+done


### PR DESCRIPTION
Reverting the hacks in #37 

This was needed because scaling in the Grunt was hardcoded to 1.0 for macOS. 