### PR TITLE
TextLine formatting via overridable method

### DIFF
--- a/nukebuild/Build.cs
+++ b/nukebuild/Build.cs
@@ -55,8 +55,9 @@ partial class Build : NukeBuild
         if (Parameters.IsLocalBuild)
         {
             Information("Repository Name: " + Parameters.RepositoryName);
-            Information("Repository Branch: " + Parameters.RepositoryBranch);
         }
+        
+        Information("Repository Branch: " + Parameters.RepositoryBranch);
         Information("Configuration: " + Parameters.Configuration);
         Information("IsLocalBuild: " + Parameters.IsLocalBuild);
         Information("IsRunningOnUnix: " + Parameters.IsRunningOnUnix);

--- a/nukebuild/BuildParameters.cs
+++ b/nukebuild/BuildParameters.cs
@@ -76,7 +76,7 @@ public partial class Build
 
             // CONFIGURATION
             MasterBranch = "refs/heads/main";
-            ReleaseBranchRegex = new("^refs/heads/release/[1-9]+$");
+            ReleaseBranchRegex = new("^refs/heads/release/[0-9]+$");
 
             ReleaseConfiguration = "Release";
             MSBuildSolution = RootDirectory / "dirs.proj";

--- a/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
+++ b/src/Avalonia.Base/Media/TextFormatting/TextLayout.cs
@@ -531,8 +531,7 @@ namespace Avalonia.Media.TextFormatting
 
                 while (true)
                 {
-                    var textLine = textFormatter.FormatLine(_textSource, _textSourceLength, MaxWidth,
-                        _paragraphProperties, previousLine?.TextLineBreak);
+                    var textLine = FormatTextLine(textFormatter, _textSource, _textSourceLength, MaxWidth, _paragraphProperties, previousLine?.TextLineBreak);
 
                     if (textLine is null)
                     {
@@ -637,6 +636,22 @@ namespace Avalonia.Media.TextFormatting
                 objectPool.TextLines.Return(ref textLines);
                 objectPool.VerifyAllReturned();
             }
+        }
+        /// <summary>
+        /// For overriding formatting of text line, for e.g. text line indentation when text line is a part of a list
+        /// </summary>
+        public virtual TextLine? FormatTextLine(
+            TextFormatter textFormatter,
+            ITextSource textSource, 
+            int textSourceLength, 
+            double maxWidth, 
+            TextParagraphProperties paragraphProperties, 
+            TextLineBreak? previousTextLineBreak)
+        {
+            var textLine = textFormatter.FormatLine(_textSource, _textSourceLength, MaxWidth,
+                       _paragraphProperties, previousTextLineBreak);
+
+            return textLine;
         }
 
         private void UpdateMetrics(


### PR DESCRIPTION
## What does the pull request do?
Adds an overridable method for controlling TextLine formatting in TextLayout.CreateTextLines().
