### PR TITLE
Change window style from layered to transparent

### DIFF
--- a/src/Windows/Avalonia.Win32/WindowImpl.cs
+++ b/src/Windows/Avalonia.Win32/WindowImpl.cs
@@ -1594,7 +1594,7 @@ namespace Avalonia.Win32
         protected override IntPtr CreateWindowOverride(ushort atom)
         {
             var hwnd = CreateWindowEx(
-                (int)(WindowStyles.WS_EX_LAYERED | (WindowStyles)0x00200000),
+                (int)(WindowStyles.WS_EX_TRANSPARENT | (WindowStyles)0x00200000),
                 atom,
                 null,
                 (int)WindowStyles.WS_CHILD | (int)WindowStyles.WS_CLIPCHILDREN | (int)WindowStyles.WS_CLIPSIBLINGS | (int)WindowStyles.WS_MAXIMIZE,
@@ -1606,8 +1606,6 @@ namespace Avalonia.Win32
                 IntPtr.Zero,
                 IntPtr.Zero,
                 IntPtr.Zero);
-
-            SetLayeredWindowAttributes(hwnd, 0, 255, LayeredWindowFlags.LWA_ALPHA);
             
             return hwnd;
         }


### PR DESCRIPTION
It seems that layered windows were invented for seeing through straight to desktop or other applications. In our case, we actually don't need such complex behaviour. We rather just need to have our child window painted only after sibling windows were painted. This is possible because Skia/OpenGL already draws to a transparent buffer which can be displayed on top of sibling windows without covering anything else.

Note that we didn't combine WS_EX_TRANSPARENT with WS_EX_LAYERED, because that would give completely different behaviour, as explained on [msdn](https://learn.microsoft.com/en-us/windows/win32/winmsg/window-features#layered-windows):

"However, if the layered window has the WS_EX_TRANSPARENT extended window style, the shape of the layered window will be ignored and the mouse events will be passed to other windows underneath the layered window."

This also fixes previous issues with anti-aliasing when using SetLayeredWindowAttributes for setting a colorkey to become transparent.
