### PR TITLE
feat: Hide window on macos

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -115,6 +115,7 @@ BEGIN_INTERFACE_MAP()
     virtual HRESULT GetPPTClipViewOrigin(AvnPoint *ret) override;
     virtual HRESULT TakeScreenshot(void** ret, int* retLength) override;
     virtual HRESULT PickColor(AvnColor color, bool* cancel, AvnColor* ret) override;
+    virtual HRESULT HideWindow(void* nsWindow) override;
 
 protected:
     NSSize lastSize;

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -701,6 +701,15 @@ HRESULT WindowBaseImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret) {
     }
 }
 
+HRESULT WindowBaseImpl::HideWindow(void* nsWindow) {
+    START_COM_CALL;
+
+    @autoreleasepool {
+        // This should only be called on WindowOverlay
+        return E_FAIL;
+    }
+}
+
 extern IAvnWindow* CreateAvnWindow(IAvnWindowEvents*events)
 {
     @autoreleasepool

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -28,6 +28,8 @@ public:
     virtual HRESULT GetPPTClipViewOrigin(AvnPoint *ret) override;
     virtual HRESULT TakeScreenshot(void** ret, int* retLength) override;
     virtual HRESULT PickColor(AvnColor color, bool* cancel, AvnColor* ret) override;
+    virtual HRESULT HideWindow(void* nsWindow) override;
+
 };
 
 #endif

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -230,6 +230,7 @@ HRESULT WindowOverlayImpl::PointToClient(AvnPoint point, AvnPoint *ret) {
 
 HRESULT WindowOverlayImpl::GetScaling(double *ret) {
     START_COM_CALL;
+
     @autoreleasepool {
         if (ret == nullptr)
             return E_POINTER;
@@ -288,11 +289,11 @@ HRESULT WindowOverlayImpl::PointToScreen(AvnPoint point, AvnPoint *ret) {
 }
 
 HRESULT WindowOverlayImpl::GetPPTClipViewOrigin(AvnPoint *ret) {
+    START_COM_CALL;
+
     // We need this whenever scrollbars are present inside PPTClipView.
     // This is a fix for PowerPoint's builtin PointsToScreenPixelsX returning
     // the same value regardless of scroll position on Macos.
-
-    START_COM_CALL;
 
     @autoreleasepool {
         if (ret == nullptr) {
@@ -313,6 +314,8 @@ HRESULT WindowOverlayImpl::GetPPTClipViewOrigin(AvnPoint *ret) {
 }
 
 HRESULT WindowOverlayImpl::TakeScreenshot(void** ret, int* retLength) {
+    START_COM_CALL;
+
     NSView* view = [[this->parentWindow contentView] superview];
     
     if (view == nullptr) {
@@ -377,6 +380,8 @@ void WindowOverlayImpl::InitializeColorPicker() {
 }
 
 HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret) {
+    START_COM_CALL;
+
     NSColor* initialColor = this->colorPanel.color;
     
     this->colorPanel.color = [NSColor colorWithRed:color.Red / 255.0
@@ -402,4 +407,15 @@ HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret
     }
 
     return S_OK;
+}
+
+HRESULT WindowOverlayImpl::HideWindow(void* nsWindow) {
+    START_COM_CALL;
+
+    @autoreleasepool {
+        auto window = (__bridge NSWindow*) nsWindow;
+
+        [window orderOut:nil];
+        return S_OK;
+    }
 }

--- a/src/Avalonia.Controls/Platform/ISpecialOverlayWindow.cs
+++ b/src/Avalonia.Controls/Platform/ISpecialOverlayWindow.cs
@@ -21,5 +21,7 @@ namespace Avalonia.Platform
         public Bitmap TakeScreenshot();
 
         public Color? PickColor(Color? initialColor);
+        
+        public void HideWindow(IntPtr nsWindow);
     }
 }

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -680,5 +680,10 @@ namespace Avalonia.Native
 
             return new Color(_outputColor.Alpha, _outputColor.Red, _outputColor.Green, _outputColor.Blue);
         }
+
+        public void HideWindow(IntPtr nsWindow)
+        {
+            _native?.HideWindow(nsWindow);
+        }
     }
 }

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -731,6 +731,7 @@ interface IAvnWindowBase : IUnknown
      HRESULT GetPPTClipViewOrigin(AvnPoint*ret);
      HRESULT TakeScreenshot(void** ret, int* retLength);
      HRESULT PickColor(AvnColor color, bool* cancel, AvnColor* ret);
+     HRESULT HideWindow([intptr]void* nsWindow);
 }
 
 [uuid(83e588f3-6981-4e48-9ea0-e1e569f79a91), cpp-virtual-inherits]


### PR DESCRIPTION
This PR exposes a new method `HideWindow` inside our `ISpecialOverlay` that allows hiding a powerpoint window. Main scenario for this is when opening a presentation temporarily to work on it. On windows we can do this directly in a "headless" mode, something that is not possible on macos, thus the need to emulate it as close as possible.

Also added a few missing START_COM_CALL's that are needed to ensure no crashes.