### PR TITLE
Update WindowOverlayImpl.mm

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -29,7 +29,7 @@ public:
     virtual HRESULT TakeScreenshot(void** ret, int* retLength) override;
     virtual HRESULT PickColor(AvnColor color, bool* cancel, AvnColor* ret) override;
     virtual HRESULT HideWindow(void* nsWindow) override;
-
+    virtual HRESULT Activate() override;
 };
 
 #endif

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -207,6 +207,26 @@ bool WindowOverlayImpl::IsOverlay()
     return true;
 }
 
+HRESULT WindowOverlayImpl::Activate() {
+    START_COM_CALL;
+
+    @autoreleasepool {
+        NSWindow *window = View.window;
+
+        if (window == nullptr) {
+            NSLog(@"ACT: Overlay window not found");
+        }
+        else {
+            if ([window makeFirstResponder:View]) {
+                NSLog(@"ACT: Successfully made the view the first responder.");
+            } else {
+                NSLog(@"ACT: Failed to make the view the first responder.");
+            }
+        }        
+    }
+
+    return S_OK;
+}
 
 HRESULT WindowOverlayImpl::PointToClient(AvnPoint point, AvnPoint *ret) {
     START_COM_CALL;

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -211,7 +211,7 @@ HRESULT WindowOverlayImpl::Activate() {
     START_COM_CALL;
 
     @autoreleasepool {
-        NSWindow *window = View.window;
+        NSWindow *window = this->parentWindow;
 
         if (window == nullptr) {
             NSLog(@"ACT: Overlay window not found");


### PR DESCRIPTION
Updated the code to detect the window linked to the View and make it active.

## What does the pull request do?
Implements the overridden method Activate() from Avalonia's WindowBaseImpl class in Altua's WindowOverlayImpl class


## What is the current behavior?
Current behavior does not have a way to force the overlay window to grab the focus.


## What is the updated/expected behavior with this PR?
SmartSelect is now able to make the request to OSX to make the overlay window the first responder of key events.

## How was the solution implemented (if it's not obvious)?
Code speaks for itself.

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
None

## Obsoletions / Deprecations
None
## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #16139
-->
