### PR TITLE
fix: Move HideWindow to IOverlayPlatform

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.h
@@ -115,7 +115,6 @@ BEGIN_INTERFACE_MAP()
     virtual HRESULT GetPPTClipViewOrigin(AvnPoint *ret) override;
     virtual HRESULT TakeScreenshot(void** ret, int* retLength) override;
     virtual HRESULT PickColor(AvnColor color, bool* cancel, AvnColor* ret) override;
-    virtual HRESULT HideWindow(void* nsWindow) override;
 
 protected:
     NSSize lastSize;

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -701,15 +701,6 @@ HRESULT WindowBaseImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret) {
     }
 }
 
-HRESULT WindowBaseImpl::HideWindow(void* nsWindow) {
-    START_COM_CALL;
-
-    @autoreleasepool {
-        // This should only be called on WindowOverlay
-        return E_FAIL;
-    }
-}
-
 extern IAvnWindow* CreateAvnWindow(IAvnWindowEvents*events)
 {
     @autoreleasepool

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -28,7 +28,6 @@ public:
     virtual HRESULT GetPPTClipViewOrigin(AvnPoint *ret) override;
     virtual HRESULT TakeScreenshot(void** ret, int* retLength) override;
     virtual HRESULT PickColor(AvnColor color, bool* cancel, AvnColor* ret) override;
-    virtual HRESULT HideWindow(void* nsWindow) override;
     virtual HRESULT Activate() override;
 };
 

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -428,14 +428,3 @@ HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret
 
     return S_OK;
 }
-
-HRESULT WindowOverlayImpl::HideWindow(void* nsWindow) {
-    START_COM_CALL;
-
-    @autoreleasepool {
-        auto window = (__bridge NSWindow*) nsWindow;
-
-        [window orderOut:nil];
-        return S_OK;
-    }
-}

--- a/native/Avalonia.Native/src/OSX/main.mm
+++ b/native/Avalonia.Native/src/OSX/main.mm
@@ -278,6 +278,18 @@ public:
         }
     }
 
+    virtual HRESULT HideWindow(void* nsWindow) override
+    {
+        START_COM_CALL;
+
+        @autoreleasepool {
+            auto window = (__bridge NSWindow*) nsWindow;
+
+            [window orderOut:nil];
+            return S_OK;
+        }
+    }
+
     virtual HRESULT CreatePopup(IAvnWindowEvents* cb, IAvnPopup** ppv) override
     {
         START_COM_CALL;

--- a/src/Avalonia.Controls/Platform/IOverlayPlatform.cs
+++ b/src/Avalonia.Controls/Platform/IOverlayPlatform.cs
@@ -8,6 +8,7 @@ namespace Avalonia.Platform
     {
         IWindowImpl CreateOverlay(IntPtr parentWindow, string parentView);
         bool AppActivate(string name);
+        void HideWindow(IntPtr nsWindow);
     }
 
 }

--- a/src/Avalonia.Controls/Platform/ISpecialOverlayWindow.cs
+++ b/src/Avalonia.Controls/Platform/ISpecialOverlayWindow.cs
@@ -22,6 +22,5 @@ namespace Avalonia.Platform
 
         public Color? PickColor(Color? initialColor);
         
-        public void HideWindow(IntPtr nsWindow);
     }
 }

--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -198,5 +198,10 @@ namespace Avalonia.Native
             var result = _factory.AppActivate(bundleIdentifier).FromComBool();
             return result;
         }
+
+        public void HideWindow(IntPtr nsWindow)
+        {
+            _factory.HideWindow(nsWindow);
+        }
     }
 }

--- a/src/Avalonia.Native/WindowImplBase.cs
+++ b/src/Avalonia.Native/WindowImplBase.cs
@@ -680,10 +680,5 @@ namespace Avalonia.Native
 
             return new Color(_outputColor.Alpha, _outputColor.Red, _outputColor.Green, _outputColor.Blue);
         }
-
-        public void HideWindow(IntPtr nsWindow)
-        {
-            _native?.HideWindow(nsWindow);
-        }
     }
 }

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -684,6 +684,7 @@ interface IAvaloniaNativeFactory : IUnknown
      HRESULT CreatePlatformSettings(IAvnPlatformSettings** ppv);
      HRESULT CreatePlatformBehaviorInhibition(IAvnPlatformBehaviorInhibition** ppv);
      bool AppActivate(char* bundleIdentifier);
+     HRESULT HideWindow([intptr]void* nsWindow);
 }
 
 [uuid(233e094f-9b9f-44a3-9a6e-6948bbdd9fb1)]
@@ -731,7 +732,6 @@ interface IAvnWindowBase : IUnknown
      HRESULT GetPPTClipViewOrigin(AvnPoint*ret);
      HRESULT TakeScreenshot(void** ret, int* retLength);
      HRESULT PickColor(AvnColor color, bool* cancel, AvnColor* ret);
-     HRESULT HideWindow([intptr]void* nsWindow);
 }
 
 [uuid(83e588f3-6981-4e48-9ea0-e1e569f79a91), cpp-virtual-inherits]


### PR DESCRIPTION
Moved `HideWindow` from `ISpecialOverlay` to `IOverlayPlatform`, for accessing via `AvaloniaLocator.Current.GetRequiredService<IOverlayPlatform>()`.

This is needed because SimpleInjector doesn't allow injecting the scoped `ISpecialOverlay` into unscoped scenarios like `PresentationWorker`.