### PR TITLE
16147 sending selected key events to AvnWindow

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -122,7 +122,13 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
                 // If the event matches specific key codes and it was intended for our AvnView, then
                 // we can directly pass it to its intended window, skipping any other event monitors.
                 // This window can be either the Powerpoint window or a completely external avalonia
-                // window, like our data editor window is.
+                // window, like our data editor window is. Possible scenarios are:
+
+                // 1) The Powerpoint window: firstResponder is our overlay (an AvnView) whenever a
+                // grunt object was recently selected by the user.
+                // 2) An external Avalonia window: firstResponder is always an AvnView.
+
+                // First responder might be null with window minimized for example, that's also okay.
 
                 // The powerpoint local event monitor can be observed when hitting Cmd+v while in the
                 // `About PowerPoint` window, causing clipboard contents to be inserted in the slide,

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -1,8 +1,5 @@
 #include "WindowOverlayImpl.h"
 #include "WindowInterfaces.h"
-#include <AppKit/AppKit.h>
-#include <Foundation/Foundation.h>
-
 
 WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnWindowEvents *events) : WindowImpl(events), WindowBaseImpl(events, false, true) {
     this->parentWindow = (__bridge NSWindow*) parentWindow;
@@ -112,14 +109,15 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
         if ((modifiers != AvnInputModifiersNone) || ([event type] == NSEventTypeFlagsChanged))
         {
             NSLog(@"WOI: Captured Key Event Flags =%ld, Event=%ld", flags, [event type]);
-            if (([event keyCode] == 9 || [event keyCode] == 0) && ([[[event window] firstResponder] isKindOfClass:[AvnView class]]))
+            if (([event keyCode] == 9 || [event keyCode] == 0) &&
+                ([[[event window] firstResponder] isKindOfClass:[AvnView class]]))
             {
                 // Current special keys are: Cmd+v (keycode 9) and Cmd+a (keycode 0)
 
                 // We need to treat these combinations in a special way in our local event monitor,
-                // in order to make sure they reach our handler. This is done because PowerPoint has
-                // its own local event monitor which stops certain events from reaching our AvnView
-                // in the normal chain of window events.
+                // in order to ensure they reach their intended handler. This is required because
+                // PowerPoint has its own local event monitor which stops certain events from
+                // reaching our AvnView in the normal chain of window events.
 
                 // If the event matches specific key codes and it was intended for our AvnView, then
                 // we can directly pass it to its intended window, skipping any other event monitors.

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -1,5 +1,6 @@
 #include "WindowOverlayImpl.h"
 #include "WindowInterfaces.h"
+#include <AppKit/AppKit.h>
 #include <Foundation/Foundation.h>
 
 
@@ -111,12 +112,12 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
         if ((modifiers != AvnInputModifiersNone) || ([event type] == NSEventTypeFlagsChanged))
         {
             NSLog(@"WOI: Captured Key Event Flags =%ld, Event=%ld", flags, [event type]);
-            if (([event keyCode] == 9 || [event keyCode] == 0) && [[event window] isKindOfClass:[AvnWindow class]])
+            if (([event keyCode] == 9 || [event keyCode] == 0) && ([[[event window] firstResponder] isKindOfClass:[AvnView class]]))
             {
                 // We treat Cmd+v (keycode 9) and Cmd+a (keycode 0) in a special way. This is similar to 
-                // what Avalonia does in the
-                // app.mm sendEvent handler but never executed in our case, because PowerPoint already has
-                // instantiated an NSApplication. Thus we need to do a similar thing from some other place.
+                // what Avalonia does in the app.mm sendEvent handler but never executed in our case, 
+                // because PowerPoint already has instantiated an NSApplication. 
+                // Thus we need to do a similar thing from some other place.
 
                 // PowerPoint catches some of the key events before getting to their normal window handler.
                 // Some of those Cmd+key events include: q, w, o, p, a, s, f, h, v, m
@@ -177,9 +178,10 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
             NSLog(@"WOI: Monitor handled key=%hu", [event keyCode]);
             return nil;
         }
-
-        NSLog(@"WOI: Monitor not handled key=%hu", [event keyCode]);
-        return event;
+        else {
+            NSLog(@"WOI: Monitor not handled key=%hu", [event keyCode]);
+            return event;
+        }
     }];
 }
 


### PR DESCRIPTION
## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
The keystrokes that represent CMD+A & CMD+V  are forced into the AvnWindow to get the expected behavior working in the app.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
When CMD+A and CMD+V are performed on top of the Visual Grid, it did not receive the key events as expected. Instead, PowerPoint global key events handler was taking over the events and performing actions like as it was performing the actions on top of the slide, but not on the visual grid (Grunt object in focus).

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
It captured the keystrokes representing CMD+A & CMD+V and forced them to the AvnWindow so that it could be handled via Oak's PrageObjectControl class.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
The event listener was modified, masking the events NSEventMaskKeyDown, NSEventMaskKeyUp 
 & NSEventMaskFlagsChanged

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #16147
Fixes #16149
-->
