### PR TITLE
14842 Fix: Special cursors reverts to regular cursor doing operations

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -405,7 +405,16 @@
 - (void)mouseDragged:(NSEvent *)event
 {
     [self mouseEvent:event withType:Move];
-    [super mouseDragged:event];
+
+    auto localPoint = [self convertPoint:[event locationInWindow] toView:self];
+    auto avnPoint = [AvnView toAvnPoint:localPoint];
+    auto point = [self translateLocalPoint:avnPoint];
+
+    if (_parent != nullptr && _parent->BaseEvents->HitTest(point)) {
+        _parent->UpdateCursor();
+    } else {
+        [super mouseDragged:event];
+    }
 }
 
 - (void)otherMouseDragged:(NSEvent *)event

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -406,13 +406,10 @@
 {
     [self mouseEvent:event withType:Move];
 
-    auto localPoint = [self convertPoint:[event locationInWindow] toView:self];
-    auto avnPoint = [AvnView toAvnPoint:localPoint];
-    auto point = [self translateLocalPoint:avnPoint];
+    if (_parent != nullptr && !_parent->IsOverlay()) {
+        // If inside PowerPoint overlay, refrain from forwarding the event further up
+        // This is because PowerPoint would overwrite our cursor icon and we don't want that
 
-    if (_parent != nullptr && _parent->BaseEvents->HitTest(point)) {
-        _parent->UpdateCursor();
-    } else {
         [super mouseDragged:event];
     }
 }

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -95,6 +95,28 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
                 return event;
     }];
 
+    [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskLeftMouseDragged handler:^NSEvent * (NSEvent * event) {
+        // NSLog(@"MONITOR drag START");
+
+        if ([event window] != this->parentWindow) {
+            // NSLog(@"MONITOR drag window=FALSE -> normal chain");
+            return event;
+        }
+        auto localPoint = [View convertPoint:[event locationInWindow] toView:View];
+        auto avnPoint = [AvnView toAvnPoint:localPoint];
+        auto point = [View translateLocalPoint:avnPoint];
+
+        auto hitTest = this->BaseEvents->HitTest(point);
+
+        if (hitTest == false) {
+            // NSLog(@"MONITOR drag outside overlay -> normal chain");
+            return event;
+        } else {
+            UpdateCursor();
+            [View mouseDragged:event]; 
+            return nil;
+        }
+    }];
     
     [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged handler:^NSEvent * (NSEvent * event) {
         bool handled = false;

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -96,10 +96,8 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
     }];
 
     [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskLeftMouseDragged handler:^NSEvent * (NSEvent * event) {
-        // NSLog(@"MONITOR drag START");
 
         if ([event window] != this->parentWindow) {
-            // NSLog(@"MONITOR drag window=FALSE -> normal chain");
             return event;
         }
         auto localPoint = [View convertPoint:[event locationInWindow] toView:View];
@@ -109,7 +107,6 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
         auto hitTest = this->BaseEvents->HitTest(point);
 
         if (hitTest == false) {
-            // NSLog(@"MONITOR drag outside overlay -> normal chain");
             return event;
         } else {
             UpdateCursor();

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -94,26 +94,6 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
 
                 return event;
     }];
-
-    [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskLeftMouseDragged handler:^NSEvent * (NSEvent * event) {
-
-        if ([event window] != this->parentWindow) {
-            return event;
-        }
-        auto localPoint = [View convertPoint:[event locationInWindow] toView:View];
-        auto avnPoint = [AvnView toAvnPoint:localPoint];
-        auto point = [View translateLocalPoint:avnPoint];
-
-        auto hitTest = this->BaseEvents->HitTest(point);
-
-        if (hitTest == false) {
-            return event;
-        } else {
-            UpdateCursor();
-            [View mouseDragged:event]; 
-            return nil;
-        }
-    }];
     
     [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged handler:^NSEvent * (NSEvent * event) {
         bool handled = false;


### PR DESCRIPTION
**High-level description**
Problem was that PowerPoint was changing the cursor back to normal while dragging something. To fix this, added a new NSEvent for dragging to update the cursor properly. Also updated the mouseDragged method to stop it from changing the cursor.

**Old behaviour**
Grabby grabby hand hand reverts to regular cursor doing rearrange operations

**New behaviour**
Grabbing hand cursor during the entire rearrange operation

**Breaking changes**
No breaking Changes

## Fixed issues
Fixes [#14842
](https://github.com/Altua/Oak/issues/14842)
