### PR TITLE
Adds native OSX openHandCursor and closedHandCursor

### DIFF
--- a/native/Avalonia.Native/src/OSX/cursor.mm
+++ b/native/Avalonia.Native/src/OSX/cursor.mm
@@ -17,6 +17,8 @@ class CursorFactory : public ComSingleObject<IAvnCursorFactory, &IID_IAvnCursorF
     Cursor* resizeRightCursor = new Cursor([NSCursor resizeRightCursor]);
     Cursor* resizeWestEastCursor = new Cursor([NSCursor resizeLeftRightCursor]);
     Cursor* operationNotAllowedCursor = new Cursor([NSCursor operationNotAllowedCursor]);
+    Cursor* openHandCursor = new Cursor([NSCursor openHandCursor]);
+    Cursor* closedHandCursor = new Cursor([NSCursor closedHandCursor]);
     Cursor* noCursor = new Cursor([NSCursor arrowCursor], true);
 
     std::map<AvnStandardCursorType, Cursor*> s_cursorMap =
@@ -44,6 +46,8 @@ class CursorFactory : public ComSingleObject<IAvnCursorFactory, &IID_IAvnCursorF
         { CursorLeftSide, resizeLeftCursor },
         { CursorRightSide, resizeRightCursor },
         { CursorNo, operationNotAllowedCursor },
+        { CursorOpenHand, openHandCursor },
+        { CursorClosedHand, closedHandCursor },
         { CursorNone, noCursor }
     };
 

--- a/src/Avalonia.Base/Input/Cursor.cs
+++ b/src/Avalonia.Base/Input/Cursor.cs
@@ -32,6 +32,8 @@ namespace Avalonia.Input
         DragCopy,
         DragLink,
         None,
+        OpenHand,
+        ClosedHand,
         
         // Not available in GTK directly, see https://www.pixelbeat.org/programming/x_cursors/
         // We might enable them later, preferably, by loading pixmax directly from theme with fallback image

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -556,9 +556,9 @@ enum AvnStandardCursorType
     CursorDragMove,
     CursorDragCopy,
     CursorDragLink,
-    CursorNone
+    CursorNone,
     CursorOpenHand,
-    CursorClosedHand,
+    CursorClosedHand
 }
 
 enum AvnWindowEdge

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -557,6 +557,8 @@ enum AvnStandardCursorType
     CursorDragCopy,
     CursorDragLink,
     CursorNone
+    CursorOpenHand,
+    CursorClosedHand,
 }
 
 enum AvnWindowEdge


### PR DESCRIPTION
## What does the pull request do?
Adds the native OSX openHandCursor and closedHandCursor.

## What is the current behavior?
Native OSX openHandCursor and closedHandCursor is not included.

## What is the updated/expected behavior with this PR?
Be able to use the native OSX openHandCursor and closedHandCursor in OAK.

## How was the solution implemented (if it's not obvious)?
N/A

## Checklist
N/A

## Obsoletions / Deprecations
N/A

## Fixed issues
Fixes [#14843](https://github.com/Altua/Oak/issues/14843)
