### PR TITLE
Update AvnView.mm

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -687,12 +687,29 @@
 
 - (NSAttributedString *)attributedSubstringForProposedRange:(NSRange)range actualRange:(NSRangePointer)actualRange
 {
-    if(actualRange){
-        range = *actualRange;
+    NSUInteger textLength = [_text length];
+
+    // Get the intersection of the range and the text length
+    NSRange validRange = NSIntersectionRange(range, NSMakeRange(0, textLength));
+    
+    // If the range is completely out of bounds, return nil. 
+    // This is to handle the case where the range is beyond the end of the text.
+    if (validRange.location > textLength) 
+    {
+        if (actualRange != NULL) 
+        {
+            *actualRange = NSMakeRange(NSNotFound, 0);
+        }
+        return nil;
     }
     
-    NSAttributedString* subString = [_text attributedSubstringFromRange:range];
-    
+    // Update actualRange if provided
+    if (actualRange != NULL) {
+        *actualRange = validRange;
+    }
+
+    // Get the substring for the valid range
+    NSAttributedString* subString = [_text attributedSubstringFromRange:validRange];
     return subString;
 }
 


### PR DESCRIPTION
Added comments
Handled completely out-of-bounds cases

## What does the pull request do?
When Inserting an emoji, the PowerPoint crashed with string out-of-bounds error. That was fixed by measuring the safe range correctly.

## What is the current behavior?
PowerPoint crashes when an emoji is entered.

## What is the updated/expected behavior with this PR?
PowerPoint does not crash and inserting the emoji to VG works.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/Documentation with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes #16466
