### PR TITLE
Fix: focus issues on mac.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -12,6 +12,7 @@ private:
     NSView* parentView;
     NSView* canvasView;
     NSColorPanel* colorPanel;
+    bool isTrackingMouse;
     FORWARD_IUNKNOWN()
     BEGIN_INTERFACE_MAP()
     INHERIT_INTERFACE_MAP(WindowBaseImpl)

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -28,6 +28,12 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
 
         if ([event window] != this->parentWindow)
         {
+            if (isTrackingMouse)
+            {
+                isTrackingMouse = false;
+                [View mouseExited: event];
+            }
+            
             //NSLog(@"MONITOR overlay=FALSE -> normal chain");
             return event;
         }
@@ -42,7 +48,8 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
 
         auto hitTest = this->BaseEvents->HitTest(point);
         static bool shouldUpdateCursor = false;
-
+        isTrackingMouse = hitTest;
+        
         if (hitTest == false)
         {
             //NSLog(@"MONITOR overlay=TRUE hitTest=FALSE -> normal chain");


### PR DESCRIPTION
## What does the pull request do?
Fixes issue https://github.com/Altua/Oak/issues/16583, where overlapping tooltips are displayed. 

## What is the current behavior?
Focus issues exists, which causes overlapping tooltips are displayed.


## What is the updated/expected behavior with this PR?
Overlapping tooltips are not displayed.


## How was the solution implemented (if it's not obvious)?
Issue was basically that a mouse exited event was not fired when the moused is moved over a window (such as the tools or color picker) overlapping with the Overlay window. The solution is manually send a mouseExited to the View when we detect that a mouse is moving over a different window.

## Checklist


## Breaking changes

## Obsoletions / Deprecations


## Fixed issues
https://github.com/Altua/Oak/issues/16583