### PR TITLE
Fix: Memory leaks

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -29,7 +29,7 @@ WindowBaseImpl::WindowBaseImpl(IAvnWindowBaseEvents *events, bool usePanel, bool
     _inResize = false;
     BaseEvents = events;
     View = [[AvnView alloc] initWithParent:this];
-    InputMethod = new AvnTextInputMethod(View);
+    InputMethod.setNoAddRef(new AvnTextInputMethod(View));
     StandardContainer = [[AutoFitContentView new] initWithContent:View];
 
     lastPositionSet = { 0, 0 };

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -12,6 +12,7 @@ private:
     NSView* parentView;
     NSView* canvasView;
     NSColorPanel* colorPanel;
+    NSArray* eventMonitors;
     FORWARD_IUNKNOWN()
     BEGIN_INTERFACE_MAP()
     INHERIT_INTERFACE_MAP(WindowBaseImpl)
@@ -20,6 +21,7 @@ private:
     AvnInputModifiers GetCommandModifier(NSEventModifierFlags modFlag);
 public:
     WindowOverlayImpl(void* parentWindow, char* parentView, IAvnWindowEvents* events);
+    virtual ~WindowOverlayImpl();
     virtual bool IsOverlay() override;
     virtual HRESULT GetScaling(double *ret) override;
     virtual HRESULT PointToClient(AvnPoint point, AvnPoint *ret) override;
@@ -29,6 +31,7 @@ public:
     virtual HRESULT TakeScreenshot(void** ret, int* retLength) override;
     virtual HRESULT PickColor(AvnColor color, bool* cancel, AvnColor* ret) override;
     virtual HRESULT Activate() override;
+    virtual HRESULT Close() override;
 };
 
 #endif

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -1,6 +1,16 @@
 #include "WindowOverlayImpl.h"
 #include "WindowInterfaces.h"
 
+WindowOverlayImpl::~WindowOverlayImpl()
+{
+    [View removeFromSuperview];
+
+    for (id monitor in eventMonitors)
+    {
+        [NSEvent removeMonitor: monitor];
+    }
+}
+
 WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnWindowEvents *events) : WindowImpl(events), WindowBaseImpl(events, false, true) {
     this->parentWindow = (__bridge NSWindow*) parentWindow;
     this->parentView = FindNSView(this->parentWindow, [NSString stringWithUTF8String:parentView]);
@@ -23,7 +33,7 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
     [[NSNotificationCenter defaultCenter] addObserver:View selector:@selector(overlayWindowDidBecomeKey:) name:NSWindowDidBecomeKeyNotification object:this->parentWindow];
     [[NSNotificationCenter defaultCenter] addObserver:View selector:@selector(overlayWindowDidResignKey:) name:NSWindowDidResignKeyNotification object:this->parentWindow];
 
-    [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskMouseMoved handler:^NSEvent * (NSEvent * event) {
+    id mouseMovedMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskMouseMoved handler:^NSEvent * (NSEvent * event) {
         //NSLog(@"MONITOR mouseMoved START");
 
         if ([event window] != this->parentWindow)
@@ -66,7 +76,7 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
         }
     }];
 
-    [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskLeftMouseDown handler:^NSEvent * (NSEvent * event) {
+    id leftMouseDownMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskLeftMouseDown handler:^NSEvent * (NSEvent * event) {
         NSLog(@"MONITOR mouseDown START");
 
         if ([event window] != this->parentWindow)
@@ -95,7 +105,7 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
                 return event;
     }];
     
-    [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged handler:^NSEvent * (NSEvent * event) {
+    id keydownMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged handler:^NSEvent * (NSEvent * event) {
         bool handled = false;
         NSUInteger flags = [event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask;
 
@@ -182,6 +192,8 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
             return event;
         }
     }];
+    
+    eventMonitors = [NSArray arrayWithObjects: mouseMovedMonitor, leftMouseDownMonitor, keydownMonitor, nil];
 }
 
 
@@ -230,6 +242,15 @@ HRESULT WindowOverlayImpl::Activate() {
     }
 
     return S_OK;
+}
+
+HRESULT WindowOverlayImpl::Close()
+{
+    START_COM_CALL;
+    HRESULT result = WindowImpl::Close();
+    [View onClosed];
+    
+    return result;
 }
 
 HRESULT WindowOverlayImpl::PointToClient(AvnPoint point, AvnPoint *ret) {

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -4,6 +4,7 @@
 WindowOverlayImpl::~WindowOverlayImpl()
 {
     [View removeFromSuperview];
+    [[NSNotificationCenter defaultCenter] removeObserver: View];
 
     for (id monitor in eventMonitors)
     {


### PR DESCRIPTION
## What does the pull request do?
Fixes memory leaks in WindowBaseImpl, WindowOverlayImpl, and AvnView.


## What is the current behavior?
Instances of AvnView and WindowOverlayImpl are not released even after closing the PP window.


## What is the updated/expected behavior with this PR?
Instances of AvnView and WindowOverlayImpl are released when PP window is closed .


## How was the solution implemented (if it's not obvious)?
Fixes incorrect reference count increments and breaks reference cycles.


## Checklist


## Breaking changes


## Obsoletions / Deprecations


## Fixed issues
Fixes https://github.com/Altua/Oak/issues/16128
