### PR TITLE
Fixes crash in AvnTextInputMethod, when a popup window is closed.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -33,7 +33,6 @@ WindowBaseImpl::WindowBaseImpl(IAvnWindowBaseEvents *events, bool usePanel, bool
     _inResize = false;
     BaseEvents = events;
     View = [[AvnView alloc] initWithParent:this];
-    InputMethod.setNoAddRef(new AvnTextInputMethod(View));
     StandardContainer = [[AutoFitContentView new] initWithContent:View];
 
     lastPositionSet = { 0, 0 };


### PR DESCRIPTION


## What does the pull request do?
Fixes a crash in AvnTextInputMethod, when a popup window is closed.


## What is the current behavior?
When a popup window is closed PP crashes.


## What is the updated/expected behavior with this PR?
PP doesn't crash when a popup window is closed.

## How was the solution implemented (if it's not obvious)?
In older version of Avalonia `InputMethod.setNoAddRef(new AvnTextInputMethod(View))` was added to fix an incorrect increment of reference counting. This is causing a crash in the latest code. Also `InputMethod = new AvnTextInputMethod(View)` is moved to a new base class `TopLevelImpl` in the latest code. So the previous changes should be reverted.


