### PR TITLE
Sent the key events to AvnView CMD+Z and CMD+Y

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -126,10 +126,11 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
         if ((modifiers != AvnInputModifiersNone) || ([event type] == NSEventTypeFlagsChanged))
         {
             NSLog(@"WOI: Captured Key Event Flags =%ld, Event=%ld", flags, [event type]);
-            if (([event keyCode] == 9 || [event keyCode] == 0) &&
+            if (([event keyCode] == 9 || [event keyCode] == 0 || [event keyCode] == 6 || [event keyCode] == 16) &&
                 ([[[event window] firstResponder] isKindOfClass:[AvnView class]]))
             {
-                // Current special keys are: Cmd+v (keycode 9) and Cmd+a (keycode 0)
+                // Current special keys are: Cmd+v (keycode 9), Cmd+a (keycode 0), Cmd+z (keycode 6) 
+                // and Cmd+y (keycode 16)
 
                 // We need to treat these combinations in a special way in our local event monitor,
                 // in order to ensure they reach their intended handler. This is required because


### PR DESCRIPTION
Sent the key events to AvnView

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Undo and Redo key events are forwarded to AnvView instead of PowerPoint


## What is the current behavior?
PowerPoint takes the control over Undo and Redo actions taking the focus away from AvnView components.


## What is the updated/expected behavior with this PR?
Invoke Undo Redo key strokes on VG

## How was the solution implemented (if it's not obvious)?
By specially handling the key codes


## Checklist


## Breaking changes
None

## Obsoletions / Deprecations
None

## Fixed issues

Fixes #16701
Fixes #16748

