### PR TITLE
Fix memory leak in AvnGlRenderTarget

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -977,23 +977,24 @@
             result = nil;
         }
     }
+    
+    NSString* firstResponderName;
+    if (hitTestResult)
+    {
+        firstResponderName = @"AvnView";
+    }
+    else
+    {
+        NSView* nextResponder = [[self window] firstResponder];
+        while (nextResponder == self)
+        {
+            nextResponder = [nextResponder nextResponder];
+        }
+        firstResponderName = NSStringFromClass([nextResponder class]);
+    }
 
     // Going with dispatch async on global queue in order to return control to powerpoint quickly and avoid UI hangs
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        NSString* firstResponderName;
-        if (hitTestResult)
-        {
-            firstResponderName = @"AvnView";
-        }
-        else
-        {
-            NSView* nextResponder = [[self window] firstResponder];
-            while (nextResponder == self)
-            {
-                nextResponder = [nextResponder nextResponder];
-            }
-            firstResponderName = NSStringFromClass([nextResponder class]);
-        }
         windowImpl->WindowEvents->LogFirstResponder([firstResponderName UTF8String]);
     });
 

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -22,6 +22,7 @@
 @class AutoFitContentView;
 
 WindowBaseImpl::~WindowBaseImpl() {
+    View = nullptr;
     Window = nullptr;
 }
 

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -22,7 +22,6 @@
 @class AutoFitContentView;
 
 WindowBaseImpl::~WindowBaseImpl() {
-    View = nullptr;
     Window = nullptr;
 }
 
@@ -32,7 +31,6 @@ WindowBaseImpl::WindowBaseImpl(IAvnWindowBaseEvents *events, bool usePanel, bool
     _shown = false;
     _inResize = false;
     BaseEvents = events;
-    View = [[AvnView alloc] initWithParent:this];
     StandardContainer = [[AutoFitContentView new] initWithContent:View];
 
     lastPositionSet = { 0, 0 };

--- a/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowBaseImpl.mm
@@ -28,11 +28,9 @@ WindowBaseImpl::~WindowBaseImpl() {
 
 WindowBaseImpl::WindowBaseImpl(IAvnWindowBaseEvents *events, bool usePanel, bool overlayWindow) : TopLevelImpl(events) {
     _children = std::list<WindowBaseImpl*>();
-
     _shown = false;
     _inResize = false;
     BaseEvents = events;
-    StandardContainer = [[AutoFitContentView new] initWithContent:View];
 
     lastPositionSet = { 0, 0 };
     hasPosition = false;

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -14,6 +14,7 @@ private:
     NSColorPanel* colorPanel;
     bool isTrackingMouse;
     NSArray* eventMonitors;
+    bool closed;
     FORWARD_IUNKNOWN()
     BEGIN_INTERFACE_MAP()
     INHERIT_INTERFACE_MAP(WindowBaseImpl)

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -255,10 +255,15 @@ HRESULT WindowOverlayImpl::Activate() {
 HRESULT WindowOverlayImpl::Close()
 {
     START_COM_CALL;
-    HRESULT result = WindowImpl::Close();
-    [View onClosed];
-    
-    return result;
+    if ( !closed ) {
+        closed = true;
+        HRESULT result = WindowImpl::Close();
+        [View onClosed];
+        BaseEvents->Closed();
+        return result;
+    }
+
+    return S_OK;
 }
 
 HRESULT WindowOverlayImpl::PointToClient(AvnPoint point, AvnPoint *ret) {


### PR DESCRIPTION


## What does the pull request do?
Fixes an issue that causes AvnGlRenderTarget objects to be retained even when the PowerPoint window is closed.  


## What is the current behavior?
When a PowerPoint window is closed, AvnGlRenderTarget object associated with the window is not released.


## What is the updated/expected behavior with this PR?
When a PowerPoint window is closed, AvnGlRenderTarget object associated with the window is also released.

## How was the solution implemented (if it's not obvious)?
Renderer and render targets are released in the close event handlers. In case of `OverlayWindow` only close method is called and close event is not sent. So the Renderers and render targets are not released. This Fix basically sends a close event from `WindowOverlayImpl::Close` method.


## Fixed issues
https://github.com/Altua/Oak/issues/16716
