### PR TITLE
Fix hide window on macos

### DIFF
--- a/native/Avalonia.Native/src/OSX/main.mm
+++ b/native/Avalonia.Native/src/OSX/main.mm
@@ -298,7 +298,11 @@ public:
         @autoreleasepool {
             auto window = (__bridge NSWindow*) nsWindow;
 
+            // Throwing all rocks at this to ensure powerpoint doesn't reshow the window
+            [window setAlphaValue:0.0];
+            [window setOpaque:NO];
             [window orderOut:nil];
+
             return S_OK;
         }
     }


### PR DESCRIPTION
In some scenarios powerpoint would override our window hiding.

From Adarsh:
Export a PPT with at least 20-30 slides consisting of Grunt objects, so it takes long time. For that duration a new blank window is visible.

Fixed it by bringing in additional guns.