### PR TITLE
Fix focus issues on macos

### DIFF
--- a/native/Avalonia.Native/src/OSX/PopupImpl.mm
+++ b/native/Avalonia.Native/src/OSX/PopupImpl.mm
@@ -25,7 +25,9 @@ private:
     PopupImpl(IAvnWindowEvents* events) : TopLevelImpl(events), WindowBaseImpl(events)
     {
         WindowEvents = events;
-        [Window setLevel:NSPopUpMenuWindowLevel];
+
+        // Don't display our popups on top of other applications
+        [Window setLevel:NSNormalWindowLevel];
     }
 protected:
     virtual NSWindowStyleMask CalculateStyleMask() override
@@ -47,6 +49,10 @@ public:
     {
         // Don't steal the focus from another windows if our parent is inactive
         if (Parent != nullptr && Parent->Window != nullptr && ![Parent->Window isKeyWindow])
+            return false;
+
+        // Don't steal focus when user hovers mouse over powerpoint while another application is focused
+        if (Parent->IsOverlay())
             return false;
 
         return WindowBaseImpl::ShouldTakeFocusOnShow();


### PR DESCRIPTION
This PR fixes some annoying focus issues on Macos.

1. On latest Avalonia 11.2.3, if the user hovered the mouse on top of a Grunt object while another application was in focus (eg. Finder), it caused the popup (eg. "Series 1") to activate and focus PowerPoint without even clicking on it. Fixed by preventing activation when the popup's parent is the overlay.

Stack trace of the activation happening:
<img width="621" alt="image" src="https://github.com/user-attachments/assets/d20f81c0-d00f-4a11-815b-d485e053d38a" />

3. Sometimes our popups (eg. color palette) would remain stuck on top of other windows (also noticeable when debugging). This was caused by the popups being created with a z-index higher than any other normal window (NSPopUpMenuWindowLevel). Fixed by downgrading to `NSNormalWindowLevel`.

This might close remaining issues from https://github.com/Altua/Oak/issues/16583.