### PR TITLE
Fix: Grunt initialization issue on some monitors

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -20,7 +20,6 @@ private:
     END_INTERFACE_MAP()
     void InitializeColorPicker();
     AvnInputModifiers GetCommandModifier(NSEventModifierFlags modFlag);
-    void FixWindowPosition();
 public:
     WindowOverlayImpl(void* parentWindow, char* parentView, IAvnWindowEvents* events);
     virtual ~WindowOverlayImpl();
@@ -28,7 +27,6 @@ public:
     virtual HRESULT GetScaling(double *ret) override;
     virtual HRESULT PointToClient(AvnPoint point, AvnPoint *ret) override;
     virtual HRESULT PointToScreen(AvnPoint point, AvnPoint *ret) override;
-    virtual HRESULT GetPosition(AvnPoint *ret) override;
     virtual HRESULT GetPPTClipViewOrigin(AvnPoint *ret) override;
     virtual HRESULT TakeScreenshot(void** ret, int* retLength) override;
     virtual HRESULT PickColor(AvnColor color, bool* cancel, AvnColor* ret) override;

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -20,6 +20,7 @@ private:
     END_INTERFACE_MAP()
     void InitializeColorPicker();
     AvnInputModifiers GetCommandModifier(NSEventModifierFlags modFlag);
+    void FixWindowPosition();
 public:
     WindowOverlayImpl(void* parentWindow, char* parentView, IAvnWindowEvents* events);
     virtual ~WindowOverlayImpl();

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -480,6 +480,6 @@ void WindowOverlayImpl::FixWindowPosition() {
     }
     
     if (!NSPointInRect(frame.origin, windowScreen.frame)) {
-        [this->parentWindow setFrameOrigin: frame.origin];
+        [this->parentWindow setFrameOrigin: windowScreen.frame.origin];
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes Grunt initialization issues on some monitors. The issue results in blank Grunt icons and/or crash while moving mouse over a PowerPoint window.


## What is the current behavior?
Grunt fails to initialize on some monitors, especially small monitors.


## What is the updated/expected behavior with this PR?
Grunt initializes successfully.


## How was the solution implemented (if it's not obvious)?
The root cause of the issue is that while initializing `OverlayWindow`, Avalonia looks for a monitor based on the window position (refer screenshot)

<img width="759" alt="Screenshot 2025-03-03 at 2 00 46 PM" src="https://github.com/user-attachments/assets/1ada4ca9-cf09-403d-9ddb-f8a57e0d8249" />

If the window position is outside the monitor, the code above throws an exception and Grunt fails to initialize. This results in blank Grunt icons and crash.

The fix is to find a monitor for the window, based on the window mid point and fix the position of the window within that monitor. If no monitor is found, window position is fixed to main monitor. 


## Fixed issues
Fixes https://github.com/Altua/Oak/issues/16790
