### PR TITLE
Fixes cursor scaling issue

### DIFF
--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -259,11 +259,7 @@ namespace Avalonia.Controls
                     x => (x as InputElement)?.GetObservable(CursorProperty) ?? Observable.Empty<Cursor>())
                 .Switch().Subscribe(cursor =>
                 {
-                    if(cursor is not null)
-                    {
-                        cursor.Scale(RenderScaling);
-                    }
-
+                    cursor?.Scale(RenderScaling);
                     PlatformImpl?.SetCursor(cursor?.PlatformImpl);
                 }
             );

--- a/src/Avalonia.Controls/TopLevel.cs
+++ b/src/Avalonia.Controls/TopLevel.cs
@@ -254,6 +254,20 @@ namespace Avalonia.Controls
 
             ClientSize = impl.ClientSize;
 
+            this.GetObservable(PointerOverElementProperty)
+                .Select(
+                    x => (x as InputElement)?.GetObservable(CursorProperty) ?? Observable.Empty<Cursor>())
+                .Switch().Subscribe(cursor =>
+                {
+                    if(cursor is not null)
+                    {
+                        cursor.Scale(RenderScaling);
+                    }
+
+                    PlatformImpl?.SetCursor(cursor?.PlatformImpl);
+                }
+            );
+
             if (((IStyleHost)this).StylingParent is IResourceHost applicationResources)
             {
                 _resourcesChangesSubscriber = new TargetWeakEventSubscriber<TopLevel, ResourcesChangedEventArgs>(


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes cursor scaling issue on Windows. Looks like code for scaling cursor missing after merging with 11.2.3. So this PR adds back the code. 


## What is the current behavior?
Cursor doesn't scale as per screen scaling


## What is the updated/expected behavior with this PR?
Cursor scales properly with the screen.

## Fixed issues
https://github.com/Altua/Oak/issues/16817
