### PR TITLE
Fix: Control click not working as intended on Mac

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -21,6 +21,7 @@ private:
     END_INTERFACE_MAP()
     void InitializeColorPicker();
     AvnInputModifiers GetCommandModifier(NSEventModifierFlags modFlag);
+    NSEvent* MakeRightMouseEvent(NSEvent* event);
 public:
     WindowOverlayImpl(void* parentWindow, char* parentView, IAvnWindowEvents* events);
     virtual ~WindowOverlayImpl();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Implements control click behavior on Mac


## What is the current behavior?
Control click acts as left mouse button click, doesn't show context menu.


## What is the updated/expected behavior with this PR?
Control click acts as right mouse click, shows context menu.


## How was the solution implemented (if it's not obvious)?
The solution is implemented by converting left mouse buttons clicks to right mouse button clicks. This is done only for clicks targeted to Grunt objects, and done at the local event monitor level.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/Altua/Oak/issues/15451
