### PR TITLE
Fix: Undo & Redo are not working while keeping the focus on the Grunt object

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.h
+++ b/native/Avalonia.Native/src/OSX/AvnView.h
@@ -27,4 +27,7 @@
 -(void) setResizeReason:(AvnPlatformResizeReason)reason;
 -(void) setRenderTarget:(NSObject<IRenderTarget>* _Nonnull)target;
 -(void) raiseAccessibilityChildrenChanged;
+
+@property (readonly, assign) WindowImpl* parent;
+
 @end

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -27,6 +27,11 @@
     NSMutableArray* _accessibilityChildren;
 }
 
+-(WindowImpl *)parent
+{
+    return _parent.tryGetWithCast<WindowImpl>();
+}
+
 - (void)onClosed
 {
     @synchronized (self)
@@ -345,6 +350,7 @@
     return YES;
 }
 
+
 - (void)mouseMoved:(NSEvent *)event
 {
     [self mouseEvent:event withType:Move];
@@ -485,12 +491,12 @@
     [super mouseExited:event];
 }
 
-- (void) keyboardEvent: (NSEvent *) event withType: (AvnRawKeyEventType)type
+- (bool) keyboardEvent: (NSEvent *) event withType: (AvnRawKeyEventType)type
 {
     auto parent = _parent.tryGet();
     if([self ignoreUserInput: false] || parent == nullptr)
     {
-        return;
+        return false;
     }
 
     auto scanCode = [event keyCode];
@@ -502,7 +508,7 @@
     auto timestamp = static_cast<uint64_t>([event timestamp] * 1000);
     auto modifiers = [self getModifiers:[event modifierFlags]];
 
-    parent->TopLevelEvents->RawKeyEvent(type, timestamp, modifiers, key, physicalKey, keySymbolUtf8);
+    return parent->TopLevelEvents->RawKeyEvent(type, timestamp, modifiers, key, physicalKey, keySymbolUtf8);
 }
 
 - (void)setModifiers:(NSEventModifierFlags)modifierFlags

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -20,7 +20,7 @@ private:
     INHERIT_INTERFACE_MAP(WindowBaseImpl)
     END_INTERFACE_MAP()
     void InitializeColorPicker();
-    AvnInputModifiers GetCommandModifier(NSEventModifierFlags modFlag);
+    static AvnInputModifiers GetCommandModifier(NSEventModifierFlags modFlag);
 public:
     WindowOverlayImpl(void* parentWindow, char* parentView, IAvnWindowEvents* events);
     virtual ~WindowOverlayImpl();

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -419,6 +419,10 @@ HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret
 
 @implementation AvnView (OverlayWindowExtension)
 
+
+// This executes before keydown events but after the monitor.
+// So this is a nice (only?) way to let PowerPoint handle the keyboard shortcuts if Avalonia or Grunt doesn't handle them at runtime.
+// Event monitor is still required for handling certain key combinations, which PowerPoint blocks from reaching here.
 - (BOOL)performKeyEquivalent:(NSEvent *)event
 {
     WindowImpl* parent = self.parent;

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -422,7 +422,7 @@ HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret
 - (BOOL)performKeyEquivalent:(NSEvent *)event
 {
     WindowImpl* parent = self.parent;
-    if (parent == nullptr || !parent->IsOverlay()){
+    if (parent == nullptr){
         return [super performKeyEquivalent: event];
     }
     
@@ -432,7 +432,7 @@ HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret
     AvnRawKeyEventType type = event.type == NSEventTypeKeyDown ? KeyDown : KeyUp;
 
     bool handled = event.window.firstResponder == self && [self keyboardEvent: event withType: type];
-    if (!handled)
+    if (!handled && parent->IsOverlay())
     {
         handled = parent->BaseEvents->MonitorKeyEvent(type, timestamp, modifiers, key);
     }

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -421,11 +421,12 @@ HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret
 
 - (BOOL)performKeyEquivalent:(NSEvent *)event
 {
-    if (!self.parent->IsOverlay()){
+    WindowImpl* parent = self.parent;
+    if (parent == nullptr || !parent->IsOverlay()){
         return [super performKeyEquivalent: event];
     }
     
-    auto modifiers = WindowOverlayImpl::GetCommandModifier([event modifierFlags]);
+    auto modifiers = WindowOverlayImpl::GetCommandModifier(event.modifierFlags);
     auto key = VirtualKeyFromScanCode(event.keyCode, event.modifierFlags);
     auto timestamp = static_cast<uint64_t>(event.timestamp * 1000);
     AvnRawKeyEventType type = event.type == NSEventTypeKeyDown ? KeyDown : KeyUp;
@@ -433,7 +434,7 @@ HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret
     bool handled = event.window.firstResponder == self && [self keyboardEvent: event withType: type];
     if (!handled)
     {
-        handled = self.parent->BaseEvents->MonitorKeyEvent(type, timestamp, modifiers, key);
+        handled = parent->BaseEvents->MonitorKeyEvent(type, timestamp, modifiers, key);
     }
     
     if (!handled)

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -116,13 +116,12 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
         return event;
     }];
     
-    // Add a list to store the special key codes that need to be sent to the AvnView
+    // Special key codes that need explicit sending to AvnView
     static const std::unordered_set<unsigned short> specialKeyCodes = {
         11,  // Cmd+b (Bold)
         34,  // Cmd+I (Italic)
         32   // Cmd+U (Underline)
     };
-
 
     id keydownMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged handler:^NSEvent * (NSEvent * event) {
         NSUInteger flags = [event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask;
@@ -130,31 +129,23 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
         AvnInputModifiers modifiers = GetCommandModifier([event modifierFlags]);
         NSLog(@"WOI: Dispatching Key Flags =%ld, Event=%ld", flags, [event type]);
 
-        // When any modifier key alone is pressed or released, the if block shall execute hence it responds to NSEventTypeFlagsChanged
-        // This shall listens to Modifier+Key events, hence modifiers != AvnInputModifiersNone is checked
-        // This conditions is placed to avoid independent key strokes from reaching the Key event handler
+        // We are only interested in special combinations and not regular keys:
+        // - Modifier alone is pressed or released (NSEventTypeFlagsChanged)
+        // - Modifier+Key events (modifiers != AvnInputModifiersNone)
         if ((modifiers != AvnInputModifiersNone) || ([event type] == NSEventTypeFlagsChanged))
         {
             NSLog(@"WOI: Captured Key Event Flags =%ld, Event=%ld", flags, [event type]);
             if ((specialKeyCodes.find([event keyCode]) != specialKeyCodes.end()) &&
                 ([[[event window] firstResponder] isKindOfClass:[AvnView class]]))
             {
-                // Some key combinations need to be treated in a special way by our local event monitor.
-                // Manually treating this here prior to PowerPoint ensures those keys reach our handlers.
-                // This is required because PowerPoint's own handlers can prevent them from reaching us
-                // in the normal processing chain of events.
+                // The normal processing chain will call `performKeyEquivalent` for most combinations,
+                // with the exception of a few special ones. We force `sendEvent` these to our AvnView,
+                // where they will reach the regular `keyDown` / `keyUp` handlers. In the future we can
+                // consider having a singular handling point for both scenarios.
 
-                // When the first responder is an AvnView, this means the user has recently interacted
-                // with one of our views so the event is most likely intended for us. This window can be
-                // either the Powerpoint window or a standalone Avalonia window, like our data editor.
-
-                // Possible AvnView scenarios are:
+                // Possible AvnView first responder scenarios are:
                 // 1) Powerpoint window: firstResponder is our overlay after a Grunt object was selected
                 // 2) Standalone Avalonia window: firstResponder is always an AvnView
-
-                // PowerPoint's special key handlers can be observed by hitting Cmd+V inside the `About`
-                // window, which results in clipboard contents being inserted into a completely different
-                // window - the presentation window.
                 
                 NSLog(@"WOI: MONITOR Forcing keyboard event to AvnWindow");
                 [[event window] sendEvent:event];

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -113,7 +113,7 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
             this->BaseEvents->OnSlideMouseActivate(point);
         }
 
-                return event;
+        return event;
     }];
     
     // Add a list to store the special key codes that need to be sent to the AvnView
@@ -451,7 +451,7 @@ HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret
         }
     }
     
-    bool handled = [self keyboardEvent: event withType: type];
+    bool handled = event.window.firstResponder == self && [self keyboardEvent: event withType: type];
     if (!handled)
     {
         handled = self.parent->BaseEvents->MonitorKeyEvent(type, timestamp, modifiers, key);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Implements performKeyEquivalent to handle the events and if the events not handled then lets PowerPoint handle them.

In current implementation there is no way to let the PowerPoint handle the key shortcuts if Grunt/Avalonia do not handle them. If the Avalonia view is the first responder then the event monitor sends shortcuts like Cmd+a, Cmd+a, Cmd+x, Cmd+v etc to the AvnView. But if AvnView doesn't handle them then there is no way to let powerpoint handle the shortcuts. When a Grunt object is selected, this prevents PowerPoint from executing  shortcuts like Cmd+a, Cmd+z etc. 

`NSView` has a method called `performKeyEquivalent` which is executed before sending key events to the view. Subclasses can override this method to handle keyboard shortcuts and if they don't, then lets other controls to handle the shortcuts. 

The solution is implemented by removing some of the shortcuts from the event monitor and implementing `performKeyEquivalent` on `AvnView` to handle the shortcuts. If `AvnView` doesn't handle the shortcuts then PowerPoint handles them. Event monitor is still required to process the shortcuts like Cmd+b, Cmd+u, Cmd+I, which PowerPoint blocks from reaching our handlers.

## What is the current behavior?
Undo/Redo doesn't work if a Grunt object is selected.

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Undo/Redo works when a Grunt object is selected.

## Fixed issues
Fixes https://github.com/Altua/Oak/issues/16880
