### PR TITLE
Fix so GetOffsetFrom visual respects adorners

### DIFF
--- a/src/Avalonia.Base/VisualExtensions.cs
+++ b/src/Avalonia.Base/VisualExtensions.cs
@@ -125,7 +125,9 @@ namespace Avalonia
                     result *= Matrix.CreateTranslation(topLeft);
                 }
 
-                if (v.CompositionVisual?.AdornedVisual is CompositionDrawListVisual compositionVisual)
+                if (v.CompositionVisual?.AdornedVisual is CompositionDrawListVisual compositionVisual
+                    && compositionVisual.Visual is not null
+                    && !ancestor.IsVisualAncestorOf(v))
                 {
                     v = compositionVisual.Visual;
                 }
@@ -139,7 +141,6 @@ namespace Avalonia
                     throw new ArgumentException("'visual' is not a descendant of 'ancestor'.");
                 }
             }
-
             return result;
         }
     }

--- a/src/Avalonia.Base/VisualExtensions.cs
+++ b/src/Avalonia.Base/VisualExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Rendering.Composition;
 using Avalonia.VisualTree;
 
 namespace Avalonia
@@ -124,7 +125,14 @@ namespace Avalonia
                     result *= Matrix.CreateTranslation(topLeft);
                 }
 
-                v = v.VisualParent;
+                if (v.CompositionVisual?.AdornedVisual is CompositionDrawListVisual compositionVisual)
+                {
+                    v = compositionVisual.Visual;
+                }
+                else
+                {
+                    v = v.VisualParent;
+                }
 
                 if (v == null)
                 {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
<!--- Give a bit of background on the PR here, together with links to with related issues etc. -->
Fix `VisualExtensions.GetOffsetFrom(Visual ancestor, Visual visual)` actually respects `AdornedVisual`.

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->
`VisualExtensions.GetOffsetFrom(Visual ancestor, Visual visual)` does not care about `AdornedVisual`

## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->
Gantt swimlane and agenda button should be clickable again 😅

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->
Taking fix from #17 🥷

## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
<!--- If the pull request fixes issue(s) list them like this: 
Fixes #123
Fixes #456
-->
Fixes [#16955](https://github.com/Altua/Oak/issues/16955)