### PR TITLE
Fix: VG and Chart popup windows appear in the wrong location after resizing the PowerPoint Window

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -31,6 +31,9 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
 
     [View setFrame:frame];
     lastSize = frame.size;
+    
+    // View must resize along with the parent.
+    View.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 
     InitializeColorPicker();
 


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes the issue where VG and Chart popup windows appear in the wrong location after resizing the PowerPoint Window.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
The view added to the overlay window did not resize when the PowerPoint window resizes, this resulted in wrong coordinates when calculating the popup position. Adding auto resizing mask to the view fixes the issue.


## Checklist

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/Altua/Oak/issues/16962
