### PR TITLE
Fix for undo issue in data editor

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -634,12 +634,18 @@
         auto keyDownHandled = [self handleKeyDown:timestamp withKey:key withPhysicalKey:physicalKey withModifiers:modifiers withKeySymbol:keySymbol];
             
         //Raise text input event for unhandled key down
-        if(!keyDownHandled){
+        if(!keyDownHandled && (event.modifierFlags & (NSEventModifierFlagCommand | NSEventModifierFlagControl)) == 0){
             if(keySymbol != nullptr && key != AvnKeyEnter){
                 auto timestamp = static_cast<uint64_t>([event timestamp] * 1000);
                 
-                parent->TopLevelEvents->RawTextInputEvent(timestamp, [keySymbol UTF8String]);
+                keyDownHandled = parent->TopLevelEvents->RawTextInputEvent(timestamp, [keySymbol UTF8String]);
             }
+        }
+        
+        // Let super class handle any unhandled commands
+        if (!keyDownHandled)
+        {
+            [super keyDown:event];
         }
     }
     

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -480,6 +480,10 @@
             [NSApp.mainWindow sendEvent:event];
         }
     }
+    else
+    {
+        [super keyDown:event];
+    }
 }
 #endif
 

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -480,6 +480,7 @@
     if (parentWindow == nullptr || !parentWindow->IsOverlay())
     {
         [super keyDown:event];
+        return;
     }
     
     // Pass any command or control key modifiers to PowerPoint window

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -27,8 +27,6 @@
 #include "AvnAutomationNode.h"
 #include "AvnString.h"
 
-#define GRUNT
-
 @implementation CLASS_NAME
 {
     ComObjectWeakPtr<WindowBaseImpl> _parent;
@@ -264,12 +262,18 @@
 #ifndef IS_NSPANEL
 -(BOOL)canBecomeMainWindow
 {
-#ifdef GRUNT
+    auto parent = _parent.tryGetWithCast<WindowBaseImpl>();
+    auto parentWindow = parent != nullptr? parent->Parent : nullptr;
+
     // In case of Grunt PowerPoint is the main window
-    return false;
-#else
-    return true;
-#endif
+    if (parentWindow != nullptr && parentWindow->IsOverlay())
+    {
+        return false;
+    }
+    else
+    {
+        return true;
+    }
 }
 #endif
 
@@ -469,9 +473,15 @@
     }
 }
 
-#ifdef GRUNT
 - (void)keyDown:(NSEvent *)event
 {
+    auto parent = _parent.tryGetWithCast<WindowBaseImpl>();
+    auto parentWindow = parent != nullptr? parent->Parent : nullptr;
+    if (parentWindow == nullptr || !parentWindow->IsOverlay())
+    {
+        [super keyDown:event];
+    }
+    
     // Pass any command or control key modifiers to PowerPoint window
     if ((event.modifierFlags & (NSEventModifierFlagCommand | NSEventModifierFlagControl)) != 0 )
     {
@@ -485,7 +495,6 @@
         [super keyDown:event];
     }
 }
-#endif
 
 - (void)sendEvent:(NSEvent *_Nonnull)event
 {

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -261,10 +261,15 @@
     return false;
 }
 
-#if !defined(IS_NSPANEL) && !defined(GRUNT)
+#ifndef IS_NSPANEL
 -(BOOL)canBecomeMainWindow
 {
+#ifdef GRUNT
+    // In case of Grunt PowerPoint is the main window
+    return false;
+#else
     return true;
+#endif
 }
 #endif
 

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -27,6 +27,8 @@
 #include "AvnAutomationNode.h"
 #include "AvnString.h"
 
+#define GRUNT
+
 @implementation CLASS_NAME
 {
     ComObjectWeakPtr<WindowBaseImpl> _parent;
@@ -259,7 +261,7 @@
     return false;
 }
 
-#ifndef IS_NSPANEL
+#if !defined(IS_NSPANEL) && !defined(GRUNT)
 -(BOOL)canBecomeMainWindow
 {
     return true;
@@ -461,6 +463,20 @@
         view = parent;
     }
 }
+
+#ifdef GRUNT
+- (void)keyDown:(NSEvent *)event
+{
+    // Pass any command or control key modifiers to PowerPoint window
+    if ((event.modifierFlags & (NSEventModifierFlagCommand | NSEventModifierFlagControl)) != 0 )
+    {
+        if (self != NSApp.mainWindow)
+        {
+            [NSApp.mainWindow sendEvent:event];
+        }
+    }
+}
+#endif
 
 - (void)sendEvent:(NSEvent *_Nonnull)event
 {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Handles Cmd+Z, Cmd+Y and few other previously unhandled key combinations in Data Editor


## What is the current behavior?
When in Data Editor pressing Cmd+Z  inserts characters 'z'  into the cell. 


## What is the updated/expected behavior with this PR?
When in Data Editor pressing Cmd+Z does undo the previous edit.


## How was the solution implemented (if it's not obvious)?
There were mainly 3 changes
1. If the key event is not handled by the , AvnView used to send the `RawTextInputEvent` with only the key symbol to the parent object. Modified this so that this happens only if cmd/ctrl keys are not pressed. This fixes the issue with inserting 'z' into the cell when Cmd+z is pressed.
2. Prevented Data Editor from becoming main window. So that we can send events to the PP window. 
3. Fixed event propagation and routed any unhandled commands to the main window. This along with the previous step handles the actual undo.


## Checklist

## Breaking changes
All keyboard shortcuts needs to be tested after merging this. 

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/Altua/Oak/issues/16947

