### PR TITLE
Changes required to fix local template loading issue on Mac

### DIFF
--- a/native/Avalonia.Native/src/OSX/StorageProvider.mm
+++ b/native/Avalonia.Native/src/OSX/StorageProvider.mm
@@ -116,6 +116,7 @@ public:
             
             if (fileUri)
             {
+                [fileUri startAccessingSecurityScopedResource];
                 *ppv = CreateAvnString([fileUri absoluteString]);
             }
             return S_OK;
@@ -125,9 +126,13 @@ public:
     virtual void ReleaseBookmark (
         IAvnString* fileUriStr
     ) override {
-        // no-op
+        @autoreleasepool
+        {
+            auto fileUri = [NSURL URLWithString: GetNSStringAndRelease(fileUriStr)];
+            [fileUri stopAccessingSecurityScopedResource];
+        }
     }
-
+    
     virtual bool OpenSecurityScope (
         IAvnString* fileUriStr
     ) override {

--- a/src/Avalonia.Controls/Platform/Dialogs/IStorageProviderFactory.cs
+++ b/src/Avalonia.Controls/Platform/Dialogs/IStorageProviderFactory.cs
@@ -10,4 +10,11 @@ namespace Avalonia.Controls.Platform;
 public interface IStorageProviderFactory
 {
     IStorageProvider CreateProvider(TopLevel topLevel);
+
+}
+
+[Unstable]
+public interface IStorageProviderFactory2
+{
+    IStorageProvider CreateProvider();
 }

--- a/src/Avalonia.Native/AvaloniaNativePlatform.cs
+++ b/src/Avalonia.Native/AvaloniaNativePlatform.cs
@@ -122,7 +122,8 @@ namespace Avalonia.Native
                 .Bind<IPlatformLifetimeEventsImpl>().ToConstant(applicationPlatform)
                 .Bind<INativeApplicationCommands>().ToConstant(new MacOSNativeMenuCommands(_factory.CreateApplicationCommands()))
                 .Bind<IActivatableLifetime>().ToSingleton<MacOSActivatableLifetime>()
-                .Bind<IStorageProviderFactory>().ToConstant(new StorageProviderApi(_factory.CreateStorageProvider(), options.AppSandboxEnabled));
+                .Bind<IStorageProviderFactory>().ToConstant(new StorageProviderApi(_factory.CreateStorageProvider(), options.AppSandboxEnabled))
+                .Bind<IStorageProviderFactory2>().ToConstant(new StorageProviderApi(_factory.CreateStorageProvider(), options.AppSandboxEnabled));
 
             var hotkeys = new PlatformHotkeyConfiguration(KeyModifiers.Meta, wholeWordTextActionModifiers: KeyModifiers.Alt);
             hotkeys.MoveCursorToTheStartOfLine.Add(new KeyGesture(Key.Left, hotkeys.CommandModifiers));

--- a/src/Avalonia.Native/StorageProviderApi.cs
+++ b/src/Avalonia.Native/StorageProviderApi.cs
@@ -16,7 +16,7 @@ using MicroCom.Runtime;
 
 namespace Avalonia.Native;
 
-internal class StorageProviderApi(IAvnStorageProvider native, bool sandboxEnabled) : IStorageProviderFactory, IDisposable
+internal class StorageProviderApi(IAvnStorageProvider native, bool sandboxEnabled) : IStorageProviderFactory, IStorageProviderFactory2, IDisposable
 {
     private readonly Dictionary<string, int> _openScopes = new();
     private readonly IAvnStorageProvider _native = native;
@@ -24,6 +24,11 @@ internal class StorageProviderApi(IAvnStorageProvider native, bool sandboxEnable
     public IStorageProvider CreateProvider(TopLevel topLevel)
     {
         return new StorageProviderImpl((TopLevelImpl)topLevel.PlatformImpl!, this);
+    }
+
+    public IStorageProvider CreateProvider()
+    {
+        return new StorageProviderNoWindowImpl(this);
     }
 
     public IStorageItem? TryGetStorageItem(Uri? itemUri, bool create = false)

--- a/src/Avalonia.Native/StorageProviderImpl.cs
+++ b/src/Avalonia.Native/StorageProviderImpl.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Avalonia.Collections.Pooled;
 using Avalonia.Platform.Storage;
 using Avalonia.Platform.Storage.FileIO;
 
@@ -29,6 +30,60 @@ internal sealed class StorageProviderImpl(TopLevelImpl topLevel, StorageProvider
     public Task<IReadOnlyList<IStorageFolder>> OpenFolderPickerAsync(FolderPickerOpenOptions options)
     {
         return native.SelectFolderDialog(topLevel, options);
+    }
+
+    public Task<IStorageBookmarkFile?> OpenFileBookmarkAsync(string bookmark)
+    {
+        return Task.FromResult(native.TryGetStorageItem(native.ReadBookmark(bookmark, false)) as IStorageBookmarkFile);
+    }
+
+    public Task<IStorageBookmarkFolder?> OpenFolderBookmarkAsync(string bookmark)
+    {
+        return Task.FromResult(native.TryGetStorageItem(native.ReadBookmark(bookmark, true)) as IStorageBookmarkFolder);
+    }
+
+    public Task<IStorageFile?> TryGetFileFromPathAsync(Uri fileUri)
+    {
+        return Task.FromResult(native.TryGetStorageItem(fileUri) as IStorageFile);
+    }
+
+    public Task<IStorageFolder?> TryGetFolderFromPathAsync(Uri folderPath)
+    {
+        return Task.FromResult(native.TryGetStorageItem(folderPath) as IStorageFolder);
+    }
+
+    public Task<IStorageFolder?> TryGetWellKnownFolderAsync(WellKnownFolder wellKnownFolder)
+    {
+        if (BclStorageProvider.TryGetWellKnownFolderCore(wellKnownFolder) is { } directoryInfo)
+        {
+            return Task.FromResult<IStorageFolder?>(new BclStorageFolder(directoryInfo));
+        }
+
+        return Task.FromResult<IStorageFolder?>(null);
+    }
+}
+
+internal sealed class StorageProviderNoWindowImpl(StorageProviderApi native) : IStorageProvider
+{
+    public bool CanOpen => false;
+
+    public bool CanSave => false;
+
+    public bool CanPickFolder => false;
+
+    public Task<IReadOnlyList<IStorageFile>> OpenFilePickerAsync(FilePickerOpenOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IStorageFile?> SaveFilePickerAsync(FilePickerSaveOptions options)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<IReadOnlyList<IStorageFolder>> OpenFolderPickerAsync(FolderPickerOpenOptions options)
+    {
+        throw new NotImplementedException();
     }
 
     public Task<IStorageBookmarkFile?> OpenFileBookmarkAsync(string bookmark)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?

Makes following changes needed for resolving issue [#17038](https://github.com/Altua/Oak/issues/17038)

1. Adds `IStorageProviderFactory2` interface and implementation to create an `IStorageProvider` instance without needing a window. This is required for using `IStorageProvider` from classes that have Singleton lifecycle or where a window pointer can not be obtained, such as Altua.Oak.Core package. But packages need IStorageProvider to resolve access to files and folders.

2. Fixes an issue or inconvenience, where file access is limited to the methods of `IStorageFile`, `IStorageFolder`, `IStorageItem`. The changes enable us to keep the existing implementation of `IFileService` and eliminate the need to reimplement `IFileService` using `IStorageFile`

## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Required for fixing [#17038](https://github.com/Altua/Oak/issues/17038)