### PR TITLE
Registers IStorageProviderFactory2 for Windows

### DIFF
--- a/src/Windows/Avalonia.Win32/Win32Platform.cs
+++ b/src/Windows/Avalonia.Win32/Win32Platform.cs
@@ -19,6 +19,7 @@ using Avalonia.Win32.Input;
 using Avalonia.Win32.Interop;
 using static Avalonia.Win32.Interop.UnmanagedMethods;
 using System.Collections.Generic;
+using Avalonia.Platform.Storage;
 
 namespace Avalonia
 {
@@ -133,7 +134,8 @@ namespace Avalonia.Win32
                 .Bind<IPlatformIconLoader>().ToConstant(s_instance)
                 .Bind<NonPumpingLockHelper.IHelperImpl>().ToConstant(NonPumpingWaitHelperImpl.Instance)
                 .Bind<IMountedVolumeInfoProvider>().ToConstant(new WindowsMountedVolumeInfoProvider())
-                .Bind<IPlatformLifetimeEventsImpl>().ToConstant(s_instance);
+                .Bind<IPlatformLifetimeEventsImpl>().ToConstant(s_instance)
+                .Bind<IStorageProviderFactory2>().ToSingleton<Win32StorageProviderFactory>();
 
             IPlatformGraphics? platformGraphics;
             if (options.CustomPlatformGraphics is not null)
@@ -345,6 +347,14 @@ namespace Avalonia.Win32
                 SetProcessDPIAware();
 
             return false;
+        }
+
+        private class Win32StorageProviderFactory : IStorageProviderFactory2
+        {
+            public IStorageProvider CreateProvider()
+            {
+                return new NoopStorageProvider();
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Registers IStorageProviderFactory2 for Windows. Required for using IStorageFolder and bookmarks.


## What is the current behavior?
If IStorageProviderFactory2 is not registered for windows, then the template loading crashes if the PR 
https://github.com/Altua/Oak/pull/17201 is merged

## What is the updated/expected behavior with this PR?
Local template loading works fine after merging the PR.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Required for fixing https://github.com/Altua/Oak/issues/17038

