### PR TITLE
Fixes root cause of focus issues on Mac

### DIFF
--- a/native/Avalonia.Native/src/OSX/Avalonia.Native.OSX.xcodeproj/project.pbxproj
+++ b/native/Avalonia.Native/src/OSX/Avalonia.Native.OSX.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		BC11A5BE2608D58F0017BAD0 /* automation.h in Headers */ = {isa = PBXBuildFile; fileRef = BC11A5BC2608D58F0017BAD0 /* automation.h */; };
 		BC11A5BF2608D58F0017BAD0 /* automation.mm in Sources */ = {isa = PBXBuildFile; fileRef = BC11A5BD2608D58F0017BAD0 /* automation.mm */; };
 		BC7C33822C066DBF00945A48 /* AvnAutomationNode.h in Headers */ = {isa = PBXBuildFile; fileRef = BC7C33812C066DBF00945A48 /* AvnAutomationNode.h */; };
+		C7017DC72DED61F300CA0E87 /* FirstResponderObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = C7017DC52DED61F300CA0E87 /* FirstResponderObserver.h */; };
+		C7017DC82DED61F300CA0E87 /* FirstResponderObserver.mm in Sources */ = {isa = PBXBuildFile; fileRef = C7017DC62DED61F300CA0E87 /* FirstResponderObserver.mm */; };
 		ED3791C42862E1F40080BD62 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED3791C32862E1F40080BD62 /* UniformTypeIdentifiers.framework */; };
 		ED754D262A97306B0078B4DF /* PlatformRenderTimer.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED754D252A97306B0078B4DF /* PlatformRenderTimer.mm */; };
 		EDF8CDCD2964CB01001EE34F /* PlatformSettings.mm in Sources */ = {isa = PBXBuildFile; fileRef = EDF8CDCC2964CB01001EE34F /* PlatformSettings.mm */; };
@@ -129,6 +131,8 @@
 		BC11A5BD2608D58F0017BAD0 /* automation.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = automation.mm; sourceTree = "<group>"; };
 		BC7C33812C066DBF00945A48 /* AvnAutomationNode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AvnAutomationNode.h; sourceTree = "<group>"; };
 		BC7C33832C066F1100945A48 /* AvnAccessibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AvnAccessibility.h; sourceTree = "<group>"; };
+		C7017DC52DED61F300CA0E87 /* FirstResponderObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FirstResponderObserver.h; sourceTree = "<group>"; };
+		C7017DC62DED61F300CA0E87 /* FirstResponderObserver.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FirstResponderObserver.mm; sourceTree = "<group>"; };
 		ED3791C32862E1F40080BD62 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		ED754D252A97306B0078B4DF /* PlatformRenderTimer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformRenderTimer.mm; sourceTree = "<group>"; };
 		EDF8CDCC2964CB01001EE34F /* PlatformSettings.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformSettings.mm; sourceTree = "<group>"; };
@@ -173,6 +177,8 @@
 		AB7A61E62147C814003C5833 = {
 			isa = PBXGroup;
 			children = (
+				C7017DC52DED61F300CA0E87 /* FirstResponderObserver.h */,
+				C7017DC62DED61F300CA0E87 /* FirstResponderObserver.mm */,
 				F10084852BFF1FB40024303E /* TopLevelImpl.mm */,
 				BC7C33832C066F1100945A48 /* AvnAccessibility.h */,
 				BC7C33812C066DBF00945A48 /* AvnAutomationNode.h */,
@@ -267,6 +273,7 @@
 				18391E1381E2D5BFD60265A9 /* AutoFitContentView.h in Headers */,
 				18391F1E2411C79405A9943A /* WindowProtocol.h in Headers */,
 				183914E50CF6D2EFC1667F7C /* WindowInterfaces.h in Headers */,
+				C7017DC72DED61F300CA0E87 /* FirstResponderObserver.h in Headers */,
 				64B1ECA861163C0EFF0E502B /* noarc.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -336,6 +343,7 @@
 				37DDA9B0219330F8002E132B /* AvnString.mm in Sources */,
 				523484CA26EA688F00EA0C2C /* trayicon.mm in Sources */,
 				AB8F7D6B21482D7F0057DBA5 /* platformthreading.mm in Sources */,
+				C7017DC82DED61F300CA0E87 /* FirstResponderObserver.mm in Sources */,
 				1A3E5EA823E9E83B00EDE661 /* rendertarget.mm in Sources */,
 				1A3E5EAE23E9FB1300EDE661 /* cgl.mm in Sources */,
 				BC11A5BF2608D58F0017BAD0 /* automation.mm in Sources */,

--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -1001,26 +1001,6 @@
             result = nil;
         }
     }
-    
-    NSString* firstResponderName;
-    if (hitTestResult)
-    {
-        firstResponderName = @"AvnView";
-    }
-    else
-    {
-        NSView* nextResponder = [[self window] firstResponder];
-        while (nextResponder == self)
-        {
-            nextResponder = [nextResponder nextResponder];
-        }
-        firstResponderName = NSStringFromClass([nextResponder class]);
-    }
-
-    // Going with dispatch async on global queue in order to return control to powerpoint quickly and avoid UI hangs
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        windowImpl->WindowEvents->LogFirstResponder([firstResponderName UTF8String]);
-    });
 
     return result;
 }

--- a/native/Avalonia.Native/src/OSX/FirstResponderObserver.h
+++ b/native/Avalonia.Native/src/OSX/FirstResponderObserver.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+#import "AvnView.h"
+
+@interface FirstResponderObserver : NSObject
+{
+    
+}
+
+-(id)initWithView: (AvnView*) view;
+
+@end

--- a/native/Avalonia.Native/src/OSX/FirstResponderObserver.mm
+++ b/native/Avalonia.Native/src/OSX/FirstResponderObserver.mm
@@ -1,0 +1,42 @@
+#import <AppKit/AppKit.h>
+#import "WindowImpl.h"
+#import "FirstResponderObserver.h"
+
+@implementation FirstResponderObserver
+{
+    AvnView* _view;
+}
+
+
+- (instancetype)initWithView: (AvnView*) view
+{
+    _view = view;
+    [[_view window] addObserver:self
+                     forKeyPath:@"firstResponder"
+                        options:NSKeyValueObservingOptionNew
+                        context:nil];
+    return self;
+}
+
+- (void)dealloc
+{
+    [[_view window] removeObserver:self forKeyPath:@"firstResponder"];
+}
+
+-(void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
+{
+    if ([keyPath isEqualToString:@"firstResponder"] && [object isKindOfClass:[NSWindow class]])
+    {
+        WindowImpl* parent = _view.parent;
+        if(parent != nullptr)
+        {
+            id firstResponder = [change valueForKey:NSKeyValueChangeNewKey];
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                NSString* firstResponderName = NSStringFromClass([firstResponder class]);
+                parent->WindowEvents->LogFirstResponder([firstResponderName UTF8String]);
+            });
+        }
+    }
+}
+
+@end

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -15,6 +15,7 @@ private:
     bool isTrackingMouse;
     NSArray* eventMonitors;
     bool closed;
+    id firstResponderObserver;
     FORWARD_IUNKNOWN()
     BEGIN_INTERFACE_MAP()
     INHERIT_INTERFACE_MAP(WindowBaseImpl)

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -1,4 +1,5 @@
 #include <unordered_set>
+#import "FirstResponderObserver.h"
 #include "WindowOverlayImpl.h"
 #include "WindowInterfaces.h"
 
@@ -24,6 +25,8 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
     [this->parentView addSubview:View];
     [this->parentWindow setInitialFirstResponder: View];
     [View setNextResponder: this->parentView];
+     
+    firstResponderObserver = [[FirstResponderObserver alloc] initWithView: View];
     
     NSRect frame = this->parentView.frame;
     frame.size.height += frame.origin.y;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Monitors `firstResponder` property of the Window than determining `firstResponder` via `hitTest` method of `AvnView`. This fixes the root cause of focus issues by preventing unexpected elements from being reported as firstResponder.


## What is the current behavior?
<!--- If the PR is a fix, describe the current incorrect behavior, otherwise delete this section. -->


## What is the updated/expected behavior with this PR?
<!--- Describe how to test the PR. -->


## How was the solution implemented (if it's not obvious)?
The `[AvnView hitTest:]` method sometimes gets executed even when mouse is hovered on some PowerPoint controls. This causes unexpected shifting of focus to the elements that are not really first responders. I believe this is the reason that in Oak WindowFocusManager class there are code to check and correct the focus.

Instead of using hitTest if we use the firstResponder property of the window, we will always get the correct firstResponder. Additional checks in the  WindowFocusManager are not necessary. And fixes the root cause of all focus issues.


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues 
Fixes #17037(https://github.com/Altua/Oak/issues/17037)

