### PR TITLE
Enable custom clipboard formats in browser

### DIFF
--- a/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.JavaScript;
 using System.Threading.Tasks;
@@ -116,11 +115,11 @@ internal static partial class InputHelper
 
     [JSImport("InputHelper.writeClipboard", AvaloniaModule.MainModuleName)]
     public static partial Task WriteClipboardAsync(JSObject globalThis,
-        [JSMarshalAs<JSType.Object>] Dictionary<string, string> data);
+        [JSMarshalAs<JSType.Array<JSType.String>>] string[] data);
 
     [JSImport("InputHelper.readClipboard", AvaloniaModule.MainModuleName)]
-    [return: JSMarshalAs<JSType.Object>]
-    public static partial Task<Dictionary<string, string>> ReadClipboardAsync(JSObject globalThis);
+    [return: JSMarshalAs<JSType.Array<JSType.String>>]
+    public static partial Task<string[]> ReadClipboardAsync(JSObject globalThis);
 
     [JSImport("InputHelper.setPointerCapture", AvaloniaModule.MainModuleName)]
     public static partial void

--- a/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.JavaScript;
 using System.Threading.Tasks;
@@ -112,6 +113,14 @@ internal static partial class InputHelper
 
     [JSImport("InputHelper.writeClipboardText", AvaloniaModule.MainModuleName)]
     public static partial Task WriteClipboardTextAsync(JSObject globalThis, string text);
+
+    [JSImport("InputHelper.writeClipboard", AvaloniaModule.MainModuleName)]
+    public static partial Task WriteClipboardAsync(JSObject globalThis,
+        [JSMarshalAs<JSType.Object>] Dictionary<string, string> data);
+
+    [JSImport("InputHelper.readClipboard", AvaloniaModule.MainModuleName)]
+    [return: JSMarshalAs<JSType.Object>]
+    public static partial Task<Dictionary<string, string>> ReadClipboardAsync(JSObject globalThis);
 
     [JSImport("InputHelper.setPointerCapture", AvaloniaModule.MainModuleName)]
     public static partial void

--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
@@ -77,21 +77,21 @@ export class InputHelper {
         return await globalThis.navigator.clipboard.writeText(text);
     }
 
-    public static async writeClipboard(globalThis: Window, data: any): Promise<void> {
+    public static async writeClipboard(globalThis: Window, data: string[]): Promise<void> {
         const obj: any = {};
-        for (const k in data) {
-            obj[k] = new Blob([data[k]], { type: "text/plain" });
+        for (let i = 0; i < data.length; i += 2) {
+            obj[data[i]] = new Blob([data[i + 1]], { type: "text/plain" });
         }
         await globalThis.navigator.clipboard.write([new ClipboardItem(obj)]);
     }
 
-    public static async readClipboard(globalThis: Window): Promise<any> {
-        const result: any = {};
+    public static async readClipboard(globalThis: Window): Promise<string[]> {
+        const result: string[] = [];
         const items = await globalThis.navigator.clipboard.read();
         for (const item of items) {
             for (const t of item.types) {
                 const blob = await item.getType(t);
-                result[t] = await blob.text();
+                result.push(t, await blob.text());
             }
         }
         return result;

--- a/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
+++ b/src/Browser/Avalonia.Browser/webapp/modules/avalonia/input.ts
@@ -77,6 +77,26 @@ export class InputHelper {
         return await globalThis.navigator.clipboard.writeText(text);
     }
 
+    public static async writeClipboard(globalThis: Window, data: any): Promise<void> {
+        const obj: any = {};
+        for (const k in data) {
+            obj[k] = new Blob([data[k]], { type: "text/plain" });
+        }
+        await globalThis.navigator.clipboard.write([new ClipboardItem(obj)]);
+    }
+
+    public static async readClipboard(globalThis: Window): Promise<any> {
+        const result: any = {};
+        const items = await globalThis.navigator.clipboard.read();
+        for (const item of items) {
+            for (const t of item.types) {
+                const blob = await item.getType(t);
+                result[t] = await blob.text();
+            }
+        }
+        return result;
+    }
+
     public static subscribeInputEvents(element: HTMLInputElement, topLevelId: number) {
         const keySub = this.subscribeKeyEvents(element, topLevelId);
         const pointerSub = this.subscribePointerEvents(element, topLevelId);


### PR DESCRIPTION
## Summary
- extend `InputHelper` to read/write structured clipboard data
- implement custom format support in browser clipboard
- expose new helpers in web module for clipboard read/write

## Testing
- `npm run build` *(fails: npm-run-all not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842b2dd1e34832aa7425a4fb7b6413e