### PR TITLE
Fixes issue with pinch zoom not working on Mac

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -22,8 +22,12 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
     // This is needed to replicate default avalonia behaviour
     // If parentview is positioned differently, we shall adjust the origin and size accordingly (bottom left coordinates)
     [this->parentView addSubview:View];
-    [this->parentWindow setInitialFirstResponder: View];
-    [View setNextResponder: this->parentView];
+    this->parentWindow.initialFirstResponder = View;
+    
+    // Next responder of AvnView should be the PPTView, on top of which the AvnView is placed.
+    // If AvnView was not added then PPTView would have been default firstResponder.
+    // So, all unhandled events of AvnView should technically go to the PPTView, not to the parentView.
+    View.nextResponder = FindNSView(this->parentWindow, @"PPTView");
     
     NSRect frame = this->parentView.frame;
     frame.size.height += frame.origin.y;


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes nextResponder of the overlay so that events are routed properly.

## What is the current behavior?
When cursor is on any Grunt object, pinch zoom gesture doesn't work.

## What is the updated/expected behavior with this PR?
Pinch zoom gesture works.

## How was the solution implemented (if it's not obvious)?
In Mac, if a view doesn't handle an event, events are sent to the next responder. By default, view's parent is the next responder. So event are routed from the subview to the parent.

In case of PowerPoint, `PPTView` by default handles the events. When Grunt adds an overlay it adds it to the `CUISplitViewContainerView`. CUISplitViewContainerView is an ancestor of `PPTView`. So the overlay is on top of `PPTView` and handles events. Any unhandled event is sent to its parent `CUISplitViewContainerView`. So `PPTView` will not get a chance to handle any events not handled by overlay.

So by setting `PPTView` as the next responder of overlay, we are making sure that any unhandled events are sent to `PPTView`. 


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes [#17487](https://github.com/Altua/Oak/issues/17487)


