### PR TITLE
Fix JS interop return type for ReadClipboardAsync

### DIFF
--- a/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
+++ b/src/Browser/Avalonia.Browser/Interop/InputHelper.cs
@@ -118,7 +118,7 @@ internal static partial class InputHelper
         [JSMarshalAs<JSType.Array<JSType.String>>] string[] data);
 
     [JSImport("InputHelper.readClipboard", AvaloniaModule.MainModuleName)]
-    [return: JSMarshalAs<JSType.Array<JSType.String>>]
+    [return: JSMarshalAs<JSType.Promise<JSType.Array<JSType.String>>>]
     public static partial Task<string[]> ReadClipboardAsync(JSObject globalThis);
 
     [JSImport("InputHelper.setPointerCapture", AvaloniaModule.MainModuleName)]


### PR DESCRIPTION
## Summary
- fix the JS marshaling attribute for `ReadClipboardAsync` to handle `Task<string[]>`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684943d60a98832a88a414edca3867b6