### PR TITLE
Fixes the issue custom margins now working properly on Mac 

### DIFF
--- a/native/Avalonia.Native/src/OSX/PopupImpl.mm
+++ b/native/Avalonia.Native/src/OSX/PopupImpl.mm
@@ -26,6 +26,13 @@ private:
     {
         WindowEvents = events;
         [Window setLevel:NSPopUpMenuWindowLevel];
+        
+        // if PP textbox is firstResponder then it will not relinquish the keyboard focus, if the popup can't become a key window.
+        NSWindow* parent = NSApp.mainWindow;
+        if ([parent isKindOfClass:NSClassFromString(@"CUIDocumentShellWindow")])
+        {
+            [GetWindowProtocol() setCanBecomeKeyWindow: true];
+        }
     }
 protected:
     virtual NSWindowStyleMask CalculateStyleMask() override


### PR DESCRIPTION

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Makes Popup window to be able to become key window when required, so that it can take keystrokes.

## What is the current behavior?
If PowerPoint textbox is in focus and custom margins popup is launched then keystrokes go to PowerPoint textbox.

## What is the updated/expected behavior with this PR?
Custom margins popup handles the keystrokes and setting margins work properly.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/Altua/Oak/issues/16885

