### PR TITLE
Corrects condition for making Popup as key window

### DIFF
--- a/native/Avalonia.Native/src/OSX/PopupImpl.mm
+++ b/native/Avalonia.Native/src/OSX/PopupImpl.mm
@@ -26,13 +26,6 @@ private:
     {
         WindowEvents = events;
         [Window setLevel:NSPopUpMenuWindowLevel];
-        
-        // if PP textbox is firstResponder then it will not relinquish the keyboard focus, if the popup can't become a key window.
-        NSWindow* parent = NSApp.mainWindow;
-        if ([parent isKindOfClass:NSClassFromString(@"CUIDocumentShellWindow")])
-        {
-            [GetWindowProtocol() setCanBecomeKeyWindow: true];
-        }
     }
 protected:
     virtual NSWindowStyleMask CalculateStyleMask() override
@@ -41,6 +34,20 @@ protected:
     }
 
 public:
+    
+    HRESULT SetParent(IAvnWindowBase *parent) override
+    {
+        auto result = WindowBaseImpl::SetParent(parent);
+        
+        // if PP textbox is firstResponder then it will not relinquish the keyboard focus, if the popup can't become a key window.
+        if (Parent != nullptr && Parent->IsOverlay() && ![NSApp.mainWindow.firstResponder isKindOfClass:[AvnView class]])
+        {
+            [GetWindowProtocol() setCanBecomeKeyWindow: true];
+        }
+        
+        return result;
+    }
+    
     virtual HRESULT Show(bool activate, bool isDialog) override
     {
         auto windowProtocol = GetWindowProtocol();


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
In PR https://github.com/Altua/Avalonia/pull/120, the condition for making Popup as key window isn't accurate. That PR basically assumes that any popup window running from PowerPoint can become key window, which is not correct. Some Popup windows need not become key windows (like tooltips). And also if a Popup is originated from a Window or View managed by Avalonia, then they need not become key window.

So, this PR fixes corrects that code. A popup window can become a key window only if it is originated (parent) is an overlay window and none of Avalonia controls are in focus.  


## What is the current behavior?
Any Popup window shown by Grunt can become key window


## What is the updated/expected behavior with this PR?
Only the Popup windows originated from overlay can become key window.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/Altua/Oak/issues/16885