### PR TITLE
Fixes Cmd+Shift+Z not working in TextEditorBox

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -130,7 +130,8 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
     static const std::unordered_set<unsigned short> specialKeyCodes = {
         11,  // Cmd+b (Bold)
         34,  // Cmd+I (Italic)
-        32   // Cmd+U (Underline)
+        32,  // Cmd+U (Underline)
+        6,   // Cmd+Shift+Z
     };
 
     id keydownMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged handler:^NSEvent * (NSEvent * event) {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Fixes Cmd+Shift+Z not working in TextEditorBox by adding key code for 'Z' to the list of keys to be handled by global keyboard monitor


## What is the current behavior?
Cmd+Shift+Z doesn't redo when editing in VG cell.

## What is the updated/expected behavior with this PR?
Cmd+Shift+Z works as expected.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes [#16838](https://github.com/Altua/Oak/issues/16838)
