### PR TITLE
Possible fix for a crash in WindowOverlayImpl destructor

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -8,14 +8,14 @@
 class WindowOverlayImpl : public virtual WindowImpl
 {
 private:
-    NSWindow* parentWindow;
-    NSView* parentView;
-    NSView* canvasView;
-    NSColorPanel* colorPanel;
-    bool isTrackingMouse;
-    NSArray* eventMonitors;
-    bool closed;
-    id firstResponderObserver;
+    NSWindow* parentWindow = nil;
+    NSView* parentView = nil;
+    NSView* canvasView = nil;
+    NSColorPanel* colorPanel = nil;
+    bool isTrackingMouse = false;
+    NSArray* eventMonitors = nil;
+    bool closed = false;
+    id firstResponderObserver = nil;
     FORWARD_IUNKNOWN()
     BEGIN_INTERFACE_MAP()
     INHERIT_INTERFACE_MAP(WindowBaseImpl)


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Explicitly initializes all the member variables of `WindowOverlayImpl` to their default values. The `closed` member variable was uninitialized and this was potentially causing a crash in `WindowOverlayImpl` destructor.

## What is the current behavior?
Some variables like `closed`, `isTrackingMouse` aren't initialized with default values and could take-up any value in the runtime. This could lead to unpredictable behavior or crashes.


## What is the updated/expected behavior with this PR?
All member variables are initialized to their default values explicitly to avoid any unpredictable behavior.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

- [ ] Added unit tests (if possible)?
- [ ] Added XML documentation to any related classes?
- [ ] Consider submitting a PR to https://github.com/AvaloniaUI/avalonia-docs with user documentation

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/Altua/Oak/issues/18106
