### PR TITLE
Fix for issue where undo doesn't work if Grunt object is selected.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -127,6 +127,10 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
     }];
     
     // Special key codes that need explicit sending to AvnView
+    // IMPORTANT:
+    // Careful while adding keys to this list.
+    // The keys are directly sent to AvnView, so PowerPoint will not get a chance to handle them.
+    // As a result keys in this list will not be handled by PowerPoint if Grunt object is selected.
     static const std::unordered_set<unsigned short> specialKeyCodes = {
         11,  // Cmd+b (Bold)
         34,  // Cmd+I (Italic)

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -130,8 +130,7 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
     static const std::unordered_set<unsigned short> specialKeyCodes = {
         11,  // Cmd+b (Bold)
         34,  // Cmd+I (Italic)
-        32,  // Cmd+U (Underline)
-        6,   // Cmd+Shift+Z
+        32   // Cmd+U (Underline)
     };
 
     id keydownMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged handler:^NSEvent * (NSEvent * event) {


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Reverts the change done to handle Cmd+Shift+Z in data editor. Adding key codes to `specialKeyCodes` blocks them from PowerPoint if Grunt object is selected. This is causing the issue.

## What is the current behavior?
Cmd+Z doesn't work if Grunt object is selected.
Cmd+Shift+Z works inside data editor.

## What is the updated/expected behavior with this PR?
Cmd+Z doesn't work if Grunt object is selected.
Cmd+Shift+Z doesn't work inside data editor when editing cells (Cmd+Y works for undo).

## How was the solution implemented (if it's not obvious)?
`specialKeyCodes` is used for blocking the keys from being handled by PowerPoint and redirects them to Grunt. There is a conflict when same key is handled by both Grunt object and PowerPoint. Need a different solution for #16838, for handling Cmd+Shift+Z inside data editor.


## Checklist

## Breaking changes
Breaks https://github.com/Altua/Oak/issues/16838

## Fixed issues
Fixes https://github.com/Altua/Oak/issues/18125
Fixes https://github.com/Altua/Oak/issues/18127
