### PR TITLE
Fixes issue where Cmd+Shift+Z doesn't work in Visual Grid.

### DIFF
--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.h
@@ -22,6 +22,7 @@ private:
     END_INTERFACE_MAP()
     void InitializeColorPicker();
     static AvnInputModifiers GetCommandModifier(NSEventModifierFlags modFlag);
+    NSEvent* OnKeyEvent(NSEvent* event);
 public:
     WindowOverlayImpl(void* parentWindow, char* parentView, IAvnWindowEvents* events);
     virtual ~WindowOverlayImpl();

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -125,44 +125,23 @@ WindowOverlayImpl::WindowOverlayImpl(void* parentWindow, char* parentView, IAvnW
 
         return event;
     }];
-    
-    // Special key codes that need explicit sending to AvnView
-    // IMPORTANT:
-    // Careful while adding keys to this list.
-    // The keys are directly sent to AvnView, so PowerPoint will not get a chance to handle them.
-    // As a result keys in this list will not be handled by PowerPoint if Grunt object is selected.
-    static const std::unordered_set<unsigned short> specialKeyCodes = {
-        11,  // Cmd+b (Bold)
-        34,  // Cmd+I (Italic)
-        32   // Cmd+U (Underline)
-    };
 
-    id keydownMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown | NSEventMaskKeyUp | NSEventMaskFlagsChanged handler:^NSEvent * (NSEvent * event) {
+    // We don't get some key combinations in our keyDown: event handler in Avalonia
+    // The reason could be that these key combinations are handled by performKeyEquivalent: of PowerPoint views up in the view hierarchy.
+    // So using a local monitor we force the command keys to Avalonia/Grunt first
+    id keydownMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown handler:^NSEvent * (NSEvent * event) {
         NSUInteger flags = [event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask;
+        BOOL isCommandModifier = (event.modifierFlags & (NSEventModifierFlagCommand | NSEventModifierFlagControl)) != 0;
 
-        AvnInputModifiers modifiers = GetCommandModifier([event modifierFlags]);
         NSLog(@"WOI: Dispatching Key Flags =%ld, Event=%ld", flags, [event type]);
-
-        // We are only interested in special combinations and not regular keys:
-        // - Modifier alone is pressed or released (NSEventTypeFlagsChanged)
-        // - Modifier+Key events (modifiers != AvnInputModifiersNone)
-        if ((modifiers != AvnInputModifiersNone) || ([event type] == NSEventTypeFlagsChanged))
+        if (isCommandModifier && [event.window.firstResponder isKindOfClass:AvnView.class])
         {
-            NSLog(@"WOI: Captured Key Event Flags =%ld, Event=%ld", flags, [event type]);
-            if ((specialKeyCodes.find([event keyCode]) != specialKeyCodes.end()) &&
-                ([[[event window] firstResponder] isKindOfClass:[AvnView class]]))
+            // Possible AvnView first responder scenarios are:
+            // 1) Powerpoint window: firstResponder is our overlay after a Grunt object was selected
+            // 2) Standalone Avalonia window: firstResponder is always an AvnView
+            NSLog(@"WOI: MONITOR Forcing keyboard event to AvnView");
+            if ([event.window.firstResponder performKeyEquivalent:event])
             {
-                // The normal processing chain will call `performKeyEquivalent` for most combinations,
-                // with the exception of a few special ones. We force `sendEvent` these to our AvnView,
-                // where they will reach the regular `keyDown` / `keyUp` handlers. In the future we can
-                // consider having a singular handling point for both scenarios.
-
-                // Possible AvnView first responder scenarios are:
-                // 1) Powerpoint window: firstResponder is our overlay after a Grunt object was selected
-                // 2) Standalone Avalonia window: firstResponder is always an AvnView
-                
-                NSLog(@"WOI: MONITOR Forcing keyboard event to AvnWindow");
-                [[event window] sendEvent:event];
                 return nil;
             }
         }
@@ -427,11 +406,17 @@ HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret
 
 // This executes before keydown events but after the monitor.
 // So this is a nice (only?) way to let PowerPoint handle the keyboard shortcuts if Avalonia or Grunt doesn't handle them at runtime.
-// Event monitor is still required for handling certain key combinations, which PowerPoint blocks from reaching here.
 - (BOOL)performKeyEquivalent:(NSEvent *)event
 {
+    // Only handle if Grunt object is selected
+    if (event.window.firstResponder != self)
+    {
+        return [super performKeyEquivalent: event];
+    }
+    
     WindowImpl* parent = self.parent;
-    if (parent == nullptr){
+    if (parent == nullptr)
+    {
         return [super performKeyEquivalent: event];
     }
     
@@ -440,7 +425,7 @@ HRESULT WindowOverlayImpl::PickColor(AvnColor color, bool* cancel, AvnColor* ret
     auto timestamp = static_cast<uint64_t>(event.timestamp * 1000);
     AvnRawKeyEventType type = event.type == NSEventTypeKeyDown ? KeyDown : KeyUp;
 
-    bool handled = event.window.firstResponder == self && [self keyboardEvent: event withType: type];
+    bool handled = [self keyboardEvent: event withType: type];
     if (!handled && parent->IsOverlay())
     {
         handled = parent->BaseEvents->MonitorKeyEvent(type, timestamp, modifiers, key);


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Eliminates the need for selective event filtering in keyboard event monitor. Instead sends all keyboard shortcuts (Key press with Cmd or Ctrl modifiers) to AvnView if Grunt object is selected. If the Grunt doesn't handle the keyboard shortcuts, then sends events for normal event handling.

## What is the current behavior?
Cmd+Shift+Z doesn't work when editing Visual Grid cell.

## What is the updated/expected behavior with this PR?
Cmd+Shift+Z works when editing Visual Grid cell.


## How was the solution implemented (if it's not obvious)?
PowerPoint event handling blocks certain events from reaching Grunt objects (Cmd+I, Cmd+U, Cmd+B, Cmd+Shift+Z). In order to handle these events we implemented an event monitor and selectively send the events to Grunt objects. We are using `[NSWindow sendEvent:]` in event monitors for these events. But `sendEvent:` doesn't return any status indicating if the event is handled. For certain events like ,`Cmd+Shift+Z`, this creates an issue. If we add the event to our list then PowerPoint will not be able to handle it, and if we don't add to the list then Grunt will not get the event.

The solution is to process the events using `performKeyEquivalent:`, so if the event is not handled by Grunt we can return it to the PowerPoint for handling. The solution also closely resembles how Cocoa handles keyboard shortcuts. Also there is no need for filtering events, we can send all events to AvnView's `performKeyEquivalent:`. If `AvnView` doesn't handle keyboard shortcut, then we return to the PowerPoint for normal event handling.

Reference:
https://nonstrict.eu/wwdcindex/wwdc2010/145/](https://nonstrict.eu/wwdcindex/wwdc2010/145/
https://www.chromium.org/developers/os-x-keyboard-handling/
https://leopard-adc.pepas.com/documentation/Cocoa/Conceptual/EventOverview/EventArchitecture/EventArchitecture.html

## Checklist

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
https://github.com/Altua/Oak/issues/18132
