### PR TITLE
Possible fix for a crash when closing PowerPoint

### DIFF
--- a/native/Avalonia.Native/src/OSX/FirstResponderObserver.mm
+++ b/native/Avalonia.Native/src/OSX/FirstResponderObserver.mm
@@ -5,13 +5,15 @@
 @implementation FirstResponderObserver
 {
     AvnView* _view;
+    NSWindow* _window;
 }
 
 
 - (instancetype)initWithView: (AvnView*) view
 {
     _view = view;
-    [[_view window] addObserver:self
+    _window = view.window;
+    [_window addObserver:self
                      forKeyPath:@"firstResponder"
                         options:NSKeyValueObservingOptionNew
                         context:nil];
@@ -20,7 +22,7 @@
 
 - (void)dealloc
 {
-    [[_view window] removeObserver:self forKeyPath:@"firstResponder"];
+    [_window removeObserver:self forKeyPath:@"firstResponder"];
 }
 
 -(void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context

--- a/native/Avalonia.Native/src/OSX/FirstResponderObserver.mm
+++ b/native/Avalonia.Native/src/OSX/FirstResponderObserver.mm
@@ -22,7 +22,7 @@
 
 - (void)dealloc
 {
-    [_window removeObserver:self forKeyPath:@"firstResponder"];
+    [_window removeObserver:self forKeyPath:@"firstResponder" context: nil];
 }
 
 -(void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context

--- a/native/Avalonia.Native/src/OSX/FirstResponderObserver.mm
+++ b/native/Avalonia.Native/src/OSX/FirstResponderObserver.mm
@@ -14,9 +14,9 @@
     _view = view;
     _window = view.window;
     [_window addObserver:self
-                     forKeyPath:@"firstResponder"
-                        options:NSKeyValueObservingOptionNew
-                        context:nil];
+              forKeyPath:@"firstResponder"
+                 options:NSKeyValueObservingOptionNew
+                 context:nil];
     return self;
 }
 

--- a/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowOverlayImpl.mm
@@ -5,6 +5,8 @@
 
 WindowOverlayImpl::~WindowOverlayImpl()
 {
+    firstResponderObserver = nil; // Cleanup before removing the view
+    
     [View removeFromSuperview];
     [[NSNotificationCenter defaultCenter] removeObserver: View];
 


### PR DESCRIPTION
On Mac OS X version 14 or earlier there seems to be a crash when closing the PowerPoint. This could be due to incorrect order of cleaning up the observer.

<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
In `OverlayWindowImpl` the FirstResponderObserver object is released in the destructor. `FirstResponderObserver` destructor removes the registered observer. But `OverlayWindowImpl` destructor removes the view before  `FirstResponderObserver` is released.  So view may point to invalid window at the time of removing the observer and it could potentially lead to crash.

This PR fixes the order of releasing the objects.

## What is the current behavior?
PowerPoint may crash while closing the presentation (may be on Mac OS X version 14 or earlier).


## What is the updated/expected behavior with this PR?
PowerPoint should not crash while closing the presentation.


## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/Altua/Oak/issues/18224
