### PR TITLE
Fixes Undo/Redo shortcut keys not working in Data Editor

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -653,12 +653,6 @@
                 keyDownHandled = parent->TopLevelEvents->RawTextInputEvent(timestamp, [keySymbol UTF8String]);
             }
         }
-        
-        // Let super class handle any unhandled commands
-        if (!keyDownHandled)
-        {
-            [super keyDown:event];
-        }
     }
     
     _lastKeyDownEvent = nullptr;

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -582,5 +582,45 @@
     NSAccessibilityPostNotification(focused, NSAccessibilityFocusedUIElementChangedNotification);
 }
 
+- (BOOL)performKeyEquivalent:(NSEvent *)event
+{
+    // Check if view can handle the shortcut
+    if ([super performKeyEquivalent: event])
+    {
+        return YES;
+    }
+    
+    // Next steps only if Command key
+    if ((event.modifierFlags & (NSEventModifierFlagCommand | NSEventModifierFlagControl)) == 0)
+    {
+        return NO;
+    }
+    
+    // If the main window handles the shortcut
+    if (NSApp.mainWindow != self && [NSApp.mainWindow performKeyEquivalent: event])
+    {
+        return YES;
+    }
+    
+    // Handle Cmd+W etc..
+    if ([NSApp.mainMenu performKeyEquivalent: event])
+    {
+        return YES;
+    }
+    
+    // Check the views of main window can handle the shortcut key
+    // Skip AvnView because AvnView doesn't pass events to repsonder chain.
+    // Also AvnView anyway should have handled shortcuts in performKeyEquivalent phase
+    NSResponder* responder = NSApp.mainWindow.firstResponder;
+    if ([responder isKindOfClass: AvnView.class])
+    {
+        responder = responder.nextResponder;
+    }
+    
+    [responder keyDown: event];
+    
+    return YES;
+}
+
 @end
 

--- a/native/Avalonia.Native/src/OSX/AvnWindow.mm
+++ b/native/Avalonia.Native/src/OSX/AvnWindow.mm
@@ -473,30 +473,6 @@
     }
 }
 
-- (void)keyDown:(NSEvent *)event
-{
-    auto parent = _parent.tryGetWithCast<WindowBaseImpl>();
-    auto parentWindow = parent != nullptr? parent->Parent : nullptr;
-    if (parentWindow == nullptr || !parentWindow->IsOverlay())
-    {
-        [super keyDown:event];
-        return;
-    }
-    
-    // Pass any command or control key modifiers to PowerPoint window
-    if ((event.modifierFlags & (NSEventModifierFlagCommand | NSEventModifierFlagControl)) != 0 )
-    {
-        if (self != NSApp.mainWindow)
-        {
-            [NSApp.mainWindow sendEvent:event];
-        }
-    }
-    else
-    {
-        [super keyDown:event];
-    }
-}
-
 - (void)sendEvent:(NSEvent *_Nonnull)event
 {
     // Debug key events


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Undo/Redo key shortcuts are handled by PowerPoint. So, the PR sends unhandled key shortcuts to PowerPoint for processing.

## What is the current behavior?
Undo/Redo Key shortcuts don't  work  in Data Editor.

## What is the updated/expected behavior with this PR?
Undo/Redo Key shortcuts work as expected.


## How was the solution implemented (if it's not obvious)?
There was an earlier solution implemented to send the unhandled key shortcuts to the PowerPoint. But due to some changes in Data Editor code (InputMethod is active while doing undo/redo) it no longer works. 

This PR uses `performKeyEquivalent:` to process the short cut keys. Earlier we were using `keyDown:` . `performKeyEquivalent:`is called before `keyDown:` and may prevent certain events from reaching the `keyDown:` . So, in `performKeyEquivalent:` we are sending all unprocessed shortcut keys to the PowerPoint for processing.

## Checklist

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
https://github.com/Altua/Oak/issues/18125
