### PR TITLE
Implements Microsoft SSO on Mac using WebKit 

### DIFF
--- a/native/Avalonia.Native/src/OSX/Avalonia.Native.OSX.xcodeproj/project.pbxproj
+++ b/native/Avalonia.Native/src/OSX/Avalonia.Native.OSX.xcodeproj/project.pbxproj
@@ -62,6 +62,9 @@
 		BC7C33822C066DBF00945A48 /* AvnAutomationNode.h in Headers */ = {isa = PBXBuildFile; fileRef = BC7C33812C066DBF00945A48 /* AvnAutomationNode.h */; };
 		C7017DC72DED61F300CA0E87 /* FirstResponderObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = C7017DC52DED61F300CA0E87 /* FirstResponderObserver.h */; };
 		C7017DC82DED61F300CA0E87 /* FirstResponderObserver.mm in Sources */ = {isa = PBXBuildFile; fileRef = C7017DC62DED61F300CA0E87 /* FirstResponderObserver.mm */; };
+		C71A03DC2EF197AC0069672D /* WebAuthenticationBroker.mm in Sources */ = {isa = PBXBuildFile; fileRef = C71A03DB2EF197AC0069672D /* WebAuthenticationBroker.mm */; };
+		C71A03DD2EF197AC0069672D /* WebAuthenticationBroker.h in Headers */ = {isa = PBXBuildFile; fileRef = C71A03DA2EF197AC0069672D /* WebAuthenticationBroker.h */; };
+		C71A03DF2EF197BC0069672D /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C71A03DE2EF197BC0069672D /* WebKit.framework */; };
 		ED3791C42862E1F40080BD62 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED3791C32862E1F40080BD62 /* UniformTypeIdentifiers.framework */; };
 		ED754D262A97306B0078B4DF /* PlatformRenderTimer.mm in Sources */ = {isa = PBXBuildFile; fileRef = ED754D252A97306B0078B4DF /* PlatformRenderTimer.mm */; };
 		EDF8CDCD2964CB01001EE34F /* PlatformSettings.mm in Sources */ = {isa = PBXBuildFile; fileRef = EDF8CDCC2964CB01001EE34F /* PlatformSettings.mm */; };
@@ -133,6 +136,9 @@
 		BC7C33832C066F1100945A48 /* AvnAccessibility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AvnAccessibility.h; sourceTree = "<group>"; };
 		C7017DC52DED61F300CA0E87 /* FirstResponderObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FirstResponderObserver.h; sourceTree = "<group>"; };
 		C7017DC62DED61F300CA0E87 /* FirstResponderObserver.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FirstResponderObserver.mm; sourceTree = "<group>"; };
+		C71A03DA2EF197AC0069672D /* WebAuthenticationBroker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebAuthenticationBroker.h; sourceTree = "<group>"; };
+		C71A03DB2EF197AC0069672D /* WebAuthenticationBroker.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebAuthenticationBroker.mm; sourceTree = "<group>"; };
+		C71A03DE2EF197BC0069672D /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		ED3791C32862E1F40080BD62 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		ED754D252A97306B0078B4DF /* PlatformRenderTimer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformRenderTimer.mm; sourceTree = "<group>"; };
 		EDF8CDCC2964CB01001EE34F /* PlatformSettings.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformSettings.mm; sourceTree = "<group>"; };
@@ -145,6 +151,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C71A03DF2EF197BC0069672D /* WebKit.framework in Frameworks */,
 				ED3791C42862E1F40080BD62 /* UniformTypeIdentifiers.framework in Frameworks */,
 				1A3E5EB023E9FE8300EDE661 /* QuartzCore.framework in Frameworks */,
 				1A3E5EAA23E9F26C00EDE661 /* IOSurface.framework in Frameworks */,
@@ -162,6 +169,7 @@
 		AB661C1C2148230E00291242 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C71A03DE2EF197BC0069672D /* WebKit.framework */,
 				ED3791C32862E1F40080BD62 /* UniformTypeIdentifiers.framework */,
 				522D5958258159C1006F7F7A /* Carbon.framework */,
 				1A3E5EAF23E9FE8300EDE661 /* QuartzCore.framework */,
@@ -177,6 +185,8 @@
 		AB7A61E62147C814003C5833 = {
 			isa = PBXGroup;
 			children = (
+				C71A03DA2EF197AC0069672D /* WebAuthenticationBroker.h */,
+				C71A03DB2EF197AC0069672D /* WebAuthenticationBroker.mm */,
 				C7017DC52DED61F300CA0E87 /* FirstResponderObserver.h */,
 				C7017DC62DED61F300CA0E87 /* FirstResponderObserver.mm */,
 				F10084852BFF1FB40024303E /* TopLevelImpl.mm */,
@@ -262,6 +272,7 @@
 				F10084842BFF1F9E0024303E /* TopLevelImpl.h in Headers */,
 				BC11A5BE2608D58F0017BAD0 /* automation.h in Headers */,
 				183916173528EC2737DBE5E1 /* WindowBaseImpl.h in Headers */,
+				C71A03DD2EF197AC0069672D /* WebAuthenticationBroker.h in Headers */,
 				1839171DCC651B0638603AC4 /* INSWindowHolder.h in Headers */,
 				183919D91DB9AAB5D700C2EA /* WindowImpl.h in Headers */,
 				BC7C33822C066DBF00945A48 /* AvnAutomationNode.h in Headers */,
@@ -361,6 +372,7 @@
 				1839125F057B0A4EB1760058 /* WindowImpl.mm in Sources */,
 				18391068E48EF96E3DB5FDAB /* ResizeScope.mm in Sources */,
 				18391D4EB311BC7EF8B8C0A6 /* AvnView.mm in Sources */,
+				C71A03DC2EF197AC0069672D /* WebAuthenticationBroker.mm in Sources */,
 				18391AA7E0BBA74D184C5734 /* AutoFitContentView.mm in Sources */,
 				5819C99C29B5EA0C00157401 /* WindowOverlayImpl.mm in Sources */,
 				ED754D262A97306B0078B4DF /* PlatformRenderTimer.mm in Sources */,

--- a/native/Avalonia.Native/src/OSX/WebAuthenticationBroker.h
+++ b/native/Avalonia.Native/src/OSX/WebAuthenticationBroker.h
@@ -1,0 +1,42 @@
+//
+//  WebAuthenticationBroker.h
+//  Avalonia.Native.OSX
+//
+//  Created by Adarsh Bhat on 15/12/25.
+//  Copyright © 2025 Avalonia. All rights reserved.
+//
+#pragma once
+
+#import <AppKit/AppKit.h>
+#import <WebKit/WebKit.h>
+#include "common.h"
+
+@interface WebAuthenticationController : NSObject<WKNavigationDelegate, NSWindowDelegate>
+@property (nonatomic, copy) NSString* redirectUrl;
+@property (nonatomic, copy) NSString* requestUrl;
+@property (nonatomic, copy) void (^completion)(NSString* url);
+@end
+
+class WebAuthenticationBroker : public ComSingleObject<IAvnWebAuthenticationBroker, &IID_IAvnWebAuthenticationBroker>
+{
+public:
+    FORWARD_IUNKNOWN()
+    
+    ~WebAuthenticationBroker()
+    {
+        _controller = nil;
+    }
+
+    virtual void Authenticate(const char* authUrl,
+                              const char* redirectUrl,
+                              IAvnSystemDialogEvents* events) override;
+    
+private:
+    void Run(const char* url, const char* callbackUrl);
+    void OnComplete(NSString* url);
+    
+    WebAuthenticationController* _controller = nil;
+    ComPtr<IAvnSystemDialogEvents> _events;
+};
+
+extern IAvnWebAuthenticationBroker* CreateWebAuthenticationBroker();

--- a/native/Avalonia.Native/src/OSX/WebAuthenticationBroker.h
+++ b/native/Avalonia.Native/src/OSX/WebAuthenticationBroker.h
@@ -1,10 +1,3 @@
-//
-//  WebAuthenticationBroker.h
-//  Avalonia.Native.OSX
-//
-//  Created by Adarsh Bhat on 15/12/25.
-//  Copyright © 2025 Avalonia. All rights reserved.
-//
 #pragma once
 
 #import <AppKit/AppKit.h>

--- a/native/Avalonia.Native/src/OSX/WebAuthenticationBroker.mm
+++ b/native/Avalonia.Native/src/OSX/WebAuthenticationBroker.mm
@@ -1,10 +1,3 @@
-//
-//  WebAuthenticationBroker.mm
-//  Avalonia.Native.OSX
-//
-//  Created by Adarsh Bhat on 15/12/25.
-//  Copyright © 2025 Avalonia. All rights reserved.
-//
 #include <AppKit/AppKit.h>
 #include <WebKit/WebKit.h>
 #include <dispatch/dispatch.h>
@@ -12,8 +5,6 @@
 #include "WebAuthenticationBroker.h"
 #include "AvnString.h"
 #include "INSWindowHolder.h"
-
-
 
 @implementation WebAuthenticationController
 {

--- a/native/Avalonia.Native/src/OSX/WebAuthenticationBroker.mm
+++ b/native/Avalonia.Native/src/OSX/WebAuthenticationBroker.mm
@@ -1,0 +1,166 @@
+//
+//  WebAuthenticationBroker.mm
+//  Avalonia.Native.OSX
+//
+//  Created by Adarsh Bhat on 15/12/25.
+//  Copyright © 2025 Avalonia. All rights reserved.
+//
+#include <AppKit/AppKit.h>
+#include <WebKit/WebKit.h>
+#include <dispatch/dispatch.h>
+#include <objc/runtime.h>
+#include "WebAuthenticationBroker.h"
+#include "AvnString.h"
+#include "INSWindowHolder.h"
+
+
+
+@implementation WebAuthenticationController
+{
+    NSWindow* _window;
+    WKWebView* _webView;
+}
+
+-(instancetype)initWithUrl: (NSString*)url redirectUrl:(NSString*)redirectUrl
+{
+    self = [super init];
+    if (self != nil)
+    {
+        self.requestUrl = url;
+        self.redirectUrl = redirectUrl;
+        
+        _window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 900, 700)
+                                              styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable)
+                                                backing:NSBackingStoreBuffered
+                                                  defer:NO];
+        _window.title = @"Sign in";
+
+        _webView = [[WKWebView alloc] initWithFrame: _window.contentView.bounds];
+        _webView.autoresizingMask  = (NSViewWidthSizable | NSViewHeightSizable);
+        [_window.contentView addSubview:_webView];
+        _window.releasedWhenClosed = NO;
+        
+        _window.delegate = self;
+        _webView.navigationDelegate = self;
+    }
+    
+    return self;
+}
+
+-(void)dealloc
+{
+}
+
+-(void)run
+{
+    NSURL* requestUrl = [NSURL URLWithString:self.requestUrl];
+    NSURLRequest* request = [NSURLRequest requestWithURL:requestUrl];
+    [_webView loadRequest:request];
+
+    [self runModalSession];
+}
+
+- (void)runModalSession
+{
+    NSModalSession session = [NSApp beginModalSessionForWindow: _window];
+    NSTimer* timer = [NSTimer scheduledTimerWithTimeInterval:1/60.0f repeats:YES block:^(NSTimer * _Nonnull timer) {
+        NSModalResponse resp = [NSApp runModalSession:session];
+        if (resp != NSModalResponseContinue) {
+            [timer invalidate];
+            [NSApp endModalSession:session];
+        }
+    }];
+}
+
+- (void)onComplete: (NSString*) url
+{
+    if (self.completion)
+    {
+        self.completion(url);
+        self.completion = nil;
+        
+        [NSApp stopModal];
+        _window.delegate = nil;
+    }
+}
+
+- (void)webView:(WKWebView *)webView decidePolicyForNavigationAction:(WKNavigationAction *)navigationAction decisionHandler:(void (^)(WKNavigationActionPolicy))decisionHandler
+{
+    NSString* url = navigationAction.request.URL.absoluteString;
+
+    if (url != nil && [url hasPrefix:self.redirectUrl])
+    {
+        decisionHandler(WKNavigationActionPolicyCancel);
+        [_window orderOut: nil];
+        [self onComplete: url];
+    }
+    else
+    {
+        decisionHandler(WKNavigationActionPolicyAllow);
+    }
+}
+
+- (void)windowWillClose:(NSNotification *)notification
+{
+    [self onComplete:nil];
+}
+
+@end
+
+void WebAuthenticationBroker::Authenticate(
+                              const char* authUrl,
+                              const char* redirectUrl,
+                              IAvnSystemDialogEvents* events)
+{
+    START_COM_CALL;
+    
+    if (authUrl == nullptr || redirectUrl == nullptr || events == nullptr)
+    {
+        return;
+    }
+    
+    _events = events;
+    Run(authUrl, redirectUrl);
+}
+
+void WebAuthenticationBroker::Run(const char* authUrl, const char* redirectUrl)
+{
+    @autoreleasepool {
+        NSMutableCharacterSet* charSet = [NSMutableCharacterSet whitespaceAndNewlineCharacterSet];
+        [charSet invert];
+        
+        NSString* startUrl = [[NSString stringWithUTF8String:authUrl] stringByAddingPercentEncodingWithAllowedCharacters: charSet];
+        
+        NSString* callbackUrl = [NSString stringWithUTF8String:redirectUrl];
+        if (startUrl == nil || callbackUrl == nil)
+        {
+            OnComplete(nil);
+            return;
+        }
+        
+        _controller = [[WebAuthenticationController alloc] initWithUrl: startUrl redirectUrl: callbackUrl];
+        _controller.completion = ^(NSString *url) {
+            this->OnComplete(url);
+        };
+        
+        [_controller run];
+    }
+}
+
+void WebAuthenticationBroker::OnComplete(NSString *url)
+{
+    if (url != nil)
+    {
+        auto uriStrings = CreateAvnStringArray(url);
+        _events->OnCompleted(uriStrings);
+    }
+    else
+    {
+        _events->OnCompleted(nullptr);
+    }    
+}
+
+IAvnWebAuthenticationBroker* CreateWebAuthenticationBroker()
+{
+    return new WebAuthenticationBroker();
+}

--- a/native/Avalonia.Native/src/OSX/WindowImpl.mm
+++ b/native/Avalonia.Native/src/OSX/WindowImpl.mm
@@ -631,6 +631,10 @@ void WindowImpl::RunModalSession(NSWindow *window)
     NSModalSession session = [NSApp beginModalSessionForWindow:window];
     
     NSTimer* timer = [NSTimer timerWithTimeInterval:1/60.0 repeats:YES block:^(NSTimer * _Nonnull timer) {
+        
+        if (NSApp.modalWindow != window)
+            return;
+        
         NSModalResponse resp = [NSApp runModalSession:session];
         if (resp != NSModalResponseContinue) {
             [timer invalidate];
@@ -638,7 +642,7 @@ void WindowImpl::RunModalSession(NSWindow *window)
         }
     }];
     
-    [[NSRunLoop mainRunLoop] addTimer: timer forMode:NSDefaultRunLoopMode];
+    [[NSRunLoop mainRunLoop] addTimer: timer forMode:NSRunLoopCommonModes];
 }
 
 extern IAvnWindow* CreateAvnWindow(IAvnWindowEvents*events)

--- a/native/Avalonia.Native/src/OSX/common.h
+++ b/native/Avalonia.Native/src/OSX/common.h
@@ -16,6 +16,7 @@ extern IAvnWindow* CreateAvnWindow(IAvnWindowEvents*events);
 extern IAvnWindow* CreateAvnOverlay(void* overlayWindow, char* parentView, IAvnWindowEvents*events);
 extern IAvnPopup* CreateAvnPopup(IAvnWindowEvents*events);
 extern IAvnStorageProvider* CreateStorageProvider();
+extern IAvnWebAuthenticationBroker* CreateWebAuthenticationBroker();
 extern IAvnScreens* CreateScreens(IAvnScreenEvents* cb);
 extern IAvnClipboard* CreateClipboard(NSPasteboard*, NSPasteboardItem*);
 extern NSPasteboardItem* TryGetPasteboardItem(IAvnClipboard*);

--- a/native/Avalonia.Native/src/OSX/main.mm
+++ b/native/Avalonia.Native/src/OSX/main.mm
@@ -3,6 +3,7 @@
 #include "common.h"
 #import "AvnView.h"
 #import "KeyTransform.h"
+#include "WebAuthenticationBroker.h"
 
 static NSString* s_appTitle = @"Avalonia";
 static int disableSetProcessName = 0;
@@ -566,6 +567,20 @@ public:
             return S_OK;
         }
     }
+
+    virtual HRESULT CreateWebAuthenticationBroker(IAvnWebAuthenticationBroker** ppv) override
+    {
+        START_COM_CALL;
+
+        @autoreleasepool
+        {
+            if (ppv == nullptr)
+                return E_POINTER;
+
+            *ppv = ::CreateWebAuthenticationBroker();
+            return S_OK;
+        }
+    }
 };
 
 extern "C" IAvaloniaNativeFactory* CreateAvaloniaNative()
@@ -703,4 +718,3 @@ NSEvent* CreateEvent(AvnKey key, AvnInputModifiers modifiers, NSWindow* window)
     
     return event;
 }
-

--- a/src/Avalonia.Native/WebAuthenticationBroker.cs
+++ b/src/Avalonia.Native/WebAuthenticationBroker.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Compatibility;
+using Avalonia.Native;
+using Avalonia.Threading;
+
+namespace Avalonia.Native
+{
+    // Only supports macOS
+    public static class WebAuthenticationBroker
+    {
+        public static async Task<WebAuthenticationResult> AuthenticateAsync(WebAuthenticatorOptions options)
+        {
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (!OperatingSystemEx.IsMacOS())
+            {
+                throw new PlatformNotSupportedException("Web authentication broker is only supported on macOS.");
+            }
+
+            var callbackUri = await WebAuthenticationBrokerApi.AuthenticateAsync(options.StartUrl, options.CallbackUrl, CancellationToken.None);
+            return new WebAuthenticationResult(callbackUri);
+        }
+    }
+
+    public sealed class WebAuthenticatorOptions
+    {
+        public WebAuthenticatorOptions(Uri startUrl, Uri callbackUrl)
+        {
+            StartUrl = startUrl ?? throw new ArgumentNullException(nameof(startUrl));
+            CallbackUrl = callbackUrl ?? throw new ArgumentNullException(nameof(callbackUrl));
+        }
+
+        public Uri StartUrl { get; }
+
+        public Uri CallbackUrl { get; }
+    }
+
+    public sealed class WebAuthenticationResult
+    {
+        public WebAuthenticationResult(Uri callbackUri)
+        {
+            CallbackUri = callbackUri ?? throw new ArgumentNullException(nameof(callbackUri));
+        }
+
+        public Uri CallbackUri { get; }
+    }
+}

--- a/src/Avalonia.Native/WebAuthenticationBrokerApi.cs
+++ b/src/Avalonia.Native/WebAuthenticationBrokerApi.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Native.Interop;
+
+namespace Avalonia.Native;
+
+public static class WebAuthenticationBrokerApi
+{
+    public static async Task<Uri> AuthenticateAsync(Uri startUrl, Uri redirectUrl, CancellationToken cancellationToken)
+    {
+        if (startUrl is null)
+        {
+            throw new ArgumentNullException(nameof(startUrl));
+        }
+
+        if (redirectUrl is null)
+        {
+            throw new ArgumentNullException(nameof(redirectUrl));
+        }
+
+        var factory = AvaloniaLocator.Current.GetService<IAvaloniaNativeFactory>() ?? throw new PlatformNotSupportedException("AvaloniaNative factory is unavailable.");
+
+        var broker = factory.CreateWebAuthenticationBroker();
+        using var events = new SystemDialogEvents();
+        using var registration = cancellationToken.Register(() => events.OnCompleted(null));
+
+        broker.Authenticate(startUrl.ToString(), redirectUrl.ToString(), events);
+
+        var results = await events.Task.ConfigureAwait(false);
+
+        broker.Dispose();
+
+        if (results.Length == 0)
+        {
+            throw new OperationCanceledException("Authentication was canceled.", cancellationToken);
+        }
+
+        if (!Uri.TryCreate(results[0], UriKind.Absolute, out var callbackUri))
+        {
+            throw new InvalidOperationException("Authentication callback URI was invalid.");
+        }
+
+
+        return callbackUri;
+    }
+
+    internal class SystemDialogEvents : NativeCallbackBase, IAvnSystemDialogEvents
+    {
+        private readonly TaskCompletionSource<string[]> _tcs = new();
+
+        public Task<string[]> Task => _tcs.Task;
+
+        public void OnCompleted(IAvnStringArray? ppv)
+        {
+            using (ppv)
+            {
+                _tcs.TrySetResult(ppv?.ToStringArray() ?? []);
+            }
+        }
+    }
+}

--- a/src/Avalonia.Native/avn.idl
+++ b/src/Avalonia.Native/avn.idl
@@ -699,6 +699,15 @@ interface IAvaloniaNativeFactory : IUnknown
      HRESULT HideWindow([intptr]void* nsWindow);
      HRESULT ShowFolder(char* path);
      HRESULT SendKeyEvent([intptr]void* nsWindow, AvnInputModifiers modifiers, AvnKey key, bool* handled);
+     HRESULT CreateWebAuthenticationBroker(IAvnWebAuthenticationBroker** ppv);
+}
+
+[uuid(7b9a4c9f-0f8f-4e5e-9c6a-2e7f1a6f3c7d)]
+interface IAvnWebAuthenticationBroker : IUnknown
+{
+     void Authenticate( [const] char* authUrl,
+                        [const] char* redirectUrl,
+                        IAvnSystemDialogEvents* events);
 }
 
 [uuid(233e094f-9b9f-44a3-9a6e-6948bbdd9fb1)]


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Implements Microsoft on Mac using a window with embedded WebView.

## What is the current behavior?
Microsoft SSO doesn't work on Mac. Fails with "permission denied" exception.

## What is the updated/expected behavior with this PR?
Microsoft SSO works on Mac


## How was the solution implemented (if it's not obvious)?
MSAL.NET doesn't support embedded WebView on Mac. It uses default system browser and listens to loopback URL by listening inbound connections on a socket (http://localhost:<port>). Microsoft SSO fails on Mac because app sandboxing prevents creating sockets for inbound connections. Apps can change this behavior by creating an exception in the entitlements. But since Grunt is a plugin it can't bypass the restriction.

However MSAL.NET does support creating a custom UI for authentication flow. This PR implements the solution by creating a Dialog with an embedded WebView (WKWebView), and configuring the MSAL to use this dialog for authentication flow.

## Checklist

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes [#18684](https://github.com/Altua/Oak/issues/18684)
