### PR TITLE
Fixes incorrect states when OnLostFocus is called on a control

### DIFF
--- a/native/Avalonia.Native/src/OSX/AvnView.mm
+++ b/native/Avalonia.Native/src/OSX/AvnView.mm
@@ -357,7 +357,7 @@
 - (BOOL) resignFirstResponder
 {
     auto parent = _parent.tryGet();
-    if(parent)
+    if(parent && !parent->IsOverlay()) // Overlay focus change handled by first responder observer
         parent->TopLevelEvents->LostFocus();
     return YES;
 }


### PR DESCRIPTION
<!--- See CONTRIBUTING.md for general guidelines on contributions -->

## What does the pull request do?
Avoid calling `LostFocus` when the `AvnView` resigns first responder. Calling `LostFocus` inside `resignFirstResponder` results in incorrect status. FocusManager still returns the old focused element when `GetFocusedElement` is called. This behaviour is different from Windows, and leads to issues. 

Since we have a `FistResponderObserver` for overlay window, focus shifting still happens properly and matches the behaviour of Windows.

## What is the current behavior?
When overlay window loses focus `Control.OnLostFocus` is called, but `FocusManager.GetFocusedElement` still returns the old focused element (instead of `null`)

## What is the updated/expected behavior with this PR?
When overlay window loses focus `Control.OnLostFocus` is called, `FocusManager.GetFocusedElement` returns `null`.

## How was the solution implemented (if it's not obvious)?
<!--- Include any information that might be of use to a reviewer here. -->


## Checklist

## Breaking changes
<!--- List any breaking changes here. -->

## Obsoletions / Deprecations
<!--- Obsolete and Deprecated attributes on APIs MUST only be included when discussed with Core team. @grokys, @kekekeks & @danwalmsley -->

## Fixed issues
Fixes https://github.com/Altua/Oak/issues/19210
Fixes https://github.com/Altua/Oak/issues/18226
Fixes https://github.com/Altua/Oak/issues/18014