### PR TITLE
Restore headless unit test dispatcher isolation

### DIFF
--- a/src/Avalonia.Base/Media/MediaContext.cs
+++ b/src/Avalonia.Base/Media/MediaContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Avalonia.Animation;
 using Avalonia.Layout;
 using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
@@ -68,6 +69,16 @@ internal partial class MediaContext : ICompositorScheduler
 
             return context;
         }
+    }
+
+    internal static void ResetForUnitTests()
+    {
+        var opts = AvaloniaLocator.Current.GetService<DispatcherOptions>() ?? new();
+        var context = new MediaContext(Dispatcher.UIThread, opts.InputStarvationTimeout);
+
+        AvaloniaLocator.CurrentMutable
+            .Bind<MediaContext>().ToConstant(context)
+            .Bind<IGlobalClock>().ToConstant(context.Clock);
     }
     
     /// <summary>

--- a/src/Headless/Avalonia.Headless/AvaloniaHeadlessPlatform.cs
+++ b/src/Headless/Avalonia.Headless/AvaloniaHeadlessPlatform.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls.Platform;
 using Avalonia.Reactive;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
+using Avalonia.Media;
 using Avalonia.Platform;
 using Avalonia.Rendering;
 using Avalonia.Rendering.Composition;
@@ -85,6 +86,17 @@ namespace Avalonia.Headless
                 .Bind<PlatformHotkeyConfiguration>().ToSingleton<PlatformHotkeyConfiguration>()
                 .Bind<KeyGestureFormatInfo>().ToConstant(new KeyGestureFormatInfo(new Dictionary<Key, string>() { }));
             Compositor = new Compositor( null);
+        }
+
+        internal static void RemakeForUnitTests()
+        {
+            var renderTimer = new RenderTimer(60);
+            AvaloniaLocator.CurrentMutable
+                .Bind<IRenderTimer>().ToConstant(renderTimer)
+                .Bind<IRenderLoop>().ToConstant(new RenderLoop(renderTimer));
+
+            MediaContext.ResetForUnitTests();
+            Compositor = new Compositor(null);
         }
 
         /// <summary>

--- a/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
+++ b/src/Headless/Avalonia.Headless/HeadlessUnitTestSession.cs
@@ -156,8 +156,15 @@ public sealed class HeadlessUnitTestSession : IDisposable
         var oldContext = SynchronizationContext.Current;
         try
         {
-            Dispatcher.ResetBeforeUnitTests();
+            Dispatcher.UIThread.EmptyAfterUnitTests();
             _appBuilder.SetupUnsafe();
+            Dispatcher.RemakeForUnitTests();
+            AvaloniaHeadlessPlatform.RemakeForUnitTests();
+            if (SynchronizationContext.Current is AvaloniaSynchronizationContext)
+            {
+                SynchronizationContext.SetSynchronizationContext(
+                    new AvaloniaSynchronizationContext(Dispatcher.UIThread, DispatcherPriority.Normal));
+            }
         }
         catch
         {
@@ -167,9 +174,9 @@ public sealed class HeadlessUnitTestSession : IDisposable
 
         return Disposable.Create(() =>
         {
+            Dispatcher.UIThread.EmptyAfterUnitTests();
             ((ToolTipService?)AvaloniaLocator.Current.GetService<IToolTipService>())?.Dispose();
             (AvaloniaLocator.Current.GetService<FontManager>() as IDisposable)?.Dispose();
-            Dispatcher.ResetForUnitTests();
             scope.Dispose();
             Dispatcher.ResetBeforeUnitTests();
             SynchronizationContext.SetSynchronizationContext(oldContext);


### PR DESCRIPTION
## Summary

Restores the Altua headless unit-test dispatcher isolation behavior that was lost during the Avalonia 11.3.12 upgrade.

The fork fix from #42 changed isolated headless tests to drain the current dispatcher before app setup, run `SetupUnsafe()`, remake the unit-test dispatcher after setup, and then drain/reset cleanly during teardown. After #141, the flow had drifted back toward the upstream `ResetBeforeUnitTests()` / `SetupUnsafe()` / `ResetForUnitTests()` pattern, which no longer preserved the fork-specific isolation semantics.

## What changed

- Restored the isolated `HeadlessUnitTestSession` lifecycle:
  - `Dispatcher.UIThread.EmptyAfterUnitTests()` before `_appBuilder.SetupUnsafe()`
  - `Dispatcher.RemakeForUnitTests()` after setup
  - teardown now drains `Dispatcher.UIThread.EmptyAfterUnitTests()`, disposes the current Avalonia services, disposes the locator scope, then calls `Dispatcher.ResetBeforeUnitTests()`
- Kept the newer upstream cleanup for `ToolTipService` and `FontManager` so the 11.3-era leak fix remains intact.
- Added a headless unit-test remake path for dispatcher-bound rendering services:
  - render timer
  - render loop
  - compositor
  - `MediaContext`
  - global clock

That extra reset is needed with current Avalonia because `AvaloniaSynchronizationContext`, `MediaContext`, the render loop, and the compositor can all capture a specific dispatcher instance. Simply remaking `Dispatcher.UIThread` after setup restores the old fork shape, but without refreshing those services, input and rendering can remain tied to the stale dispatcher.

## Validation

Passed locally with the pinned SDK (`8.0.404`):

- `dotnet build src/Headless/Avalonia.Headless/Avalonia.Headless.csproj --no-restore`
- `dotnet test tests/Avalonia.Headless.XUnit.PerTest.UnitTests/Avalonia.Headless.XUnit.PerTest.UnitTests.csproj --no-restore`
- `dotnet test tests/Avalonia.Headless.XUnit.PerAssembly.UnitTests/Avalonia.Headless.XUnit.PerAssembly.UnitTests.csproj --no-restore`
- `dotnet test tests/Avalonia.Headless.NUnit.PerTest.UnitTests/Avalonia.Headless.NUnit.PerTest.UnitTests.csproj --no-restore`

The headless suites pass with the existing intentional delayed-post test skipped.
